### PR TITLE
Add @ora-ai/ax — scan + journey CLI powered by ora's hosted APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# ora platform API (agentic journeys / runs). Copy to `.env` and fill in.
+# The audit scan uses the public ora.ai host and needs none of these —
+# `ora audit <url>` works with zero configuration.
+
+# Secret API key (looks like ora_sk_...). Exchanged for a short-lived bearer token.
+ORA_API_KEY=
+
+# Platform API base. Defaults to staging if unset.
+ORA_PLATFORM_URL=https://api.staging.agentfront.sh
+
+# Public scan API base. Defaults to https://ora.ai if unset.
+# ORA_API_URL=https://ora.ai

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+coverage/
+.env
+*.tsbuildinfo
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 era labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,151 @@
+# ax — the ora CLI
+
+Score any site's agent readiness — and watch real AI agents navigate it. Powered by [ora](https://ora.ai)'s hosted APIs.
+
+```
+npx @ora-ai/ax audit https://stripe.com
+```
+
+Two commands:
+
+- **`audit <url>`** — run ora's hosted agent-readiness scan against a site: live progress, then a layered report of what passed, what's broken, and exactly how to fix it (or `--json`). No account or API key needed.
+- **`journey "<intent>"`** — send a real AI agent (claude-code, codex, …) at a site and watch its navigation live as a boxed node-graph, then get the scored insight, tokens, and cost. Requires an `ORA_API_KEY`.
+
+## audit
+
+```
+ax audit <url> [--json] [--min-score n] [--show-passing] [--show-skipped]
+```
+
+```
+  https://stripe.com  71/100 Good
+  Stripe offers strong developer resource discoverability, but lacks an OpenAPI specification.
+
+  Discovery   ██████░░░░ 6/9 passed · 1 skipped
+    ✗ Issues (3 · +4 pts)
+    ┌───┬──────────────┬───────────────────────────┬──────────────────────────────┐
+    │   │ Check        │ What's wrong              │ How to fix                   │
+    ├───┼──────────────┼───────────────────────────┼──────────────────────────────┤
+    │ ✗ │ sitemap.md   │ status 404                │ Publish /sitemap.md listing… │
+    ├───┼──────────────┼───────────────────────────┼──────────────────────────────┤
+    │ ⚠ │ robots.txt   │ partially restricted      │ Allow AI crawlers in robots… │
+    └───┴──────────────┴───────────────────────────┴──────────────────────────────┘
+
+  Run with --show-passing to list all 18 passing checks
+  2 checks skipped — run with --show-skipped to see them
+```
+
+| Flag | Effect |
+|---|---|
+| `--json` | Full machine-readable result on stdout (every check, all layers), nothing else |
+| `--min-score <n>` | Exit `1` if the score is below `n` (for CI gates) |
+| `--show-passing` | List every passing check, not just the per-layer summary bar |
+| `--show-skipped` | Include not-applicable/pending checks with their reason |
+
+Issues are ordered by estimated score gain — the top row is the highest-impact fix. The public scan API is rate limited to ~10 scans/min per IP.
+
+## journey
+
+```
+ax journey "<intent>" [--domain d] [--harness h] [--model m] [--json]
+```
+
+```
+ax journey "Find the API docs and how to authenticate" --domain stripe.com
+```
+
+Triggers a real agent run on ora's platform and renders the journey live — the whole graph repaints in place as the agent moves:
+
+```
+  ▶ stripe.com  ·  claude-code
+
+  9 steps  ·  3 reasoning  ·  1 search
+
+  ╭────────────────────────────────────────────────────────────────────────────────╮
+  │ ◆ Find the API docs and how to authenticate. Fetch the actual pages to verify. │
+  ╰─┬──────────────────────────────────────────────────────────────────────────────╯
+    │  (…) The user is asking me to find the API documentation for Stripe…
+    │  ╭──────────────────────────────────────────────╮
+    ╰──┤ 🔍 "Stripe API documentation authentication" │
+       ╰─┬────────────────────────────────────────────╯
+         │  ╭─────────────────────────────────────────╮
+         ├──┤ 🌐 docs.stripe.com/api/authentication ✓ │
+         │  ╰─────────────────────────────────────────╯
+         │  ╭───────────────────────────╮
+         ╰──┤ 🌐 docs.stripe.com/apis ✓ │
+            ╰───────────────────────────╯
+
+  ────────────────────────────────────────────────────
+  ✓ completed  9 turns · 30.8s · 119.1k tokens · $0.031
+
+  Visibility  █████████████████████░ 95/100   ✓ intent satisfied
+```
+
+Edges come from ora's own per-step attribution (link-follows nest under the page that linked them; searches hang off the intent). `(…)` markers are the agent's reasoning, placed above the action it led to.
+
+| Flag | Effect |
+|---|---|
+| `--domain <d>` | Site the agent targets (e.g. `stripe.com`) |
+| `--harness <h>` | Agent harness: `claude-code` (default), `codex`, `aider`, `openai-web`, `claude-web`, `tavily` |
+| `--model <m>` | Model override (e.g. `claude-haiku-4-5-20251001` — cheap and good for demos) |
+| `--json` | Full result as JSON: run metadata, usage, insight, and the raw trajectory |
+
+Note: run-to-run variance is real — agents sometimes answer from search snippets without fetching, which scores differently. Run a few journeys before drawing conclusions.
+
+### Setup
+
+`journey` needs an ora platform API key (scopes `runs:read` + `runs:write`). The CLI reads plain environment variables — nothing is loaded implicitly:
+
+```sh
+export ORA_API_KEY=ora_sk_...        # your shell, CI secret store, etc.
+ax journey "Find the pricing page" --domain example.com
+```
+
+For local development, copy `.env.example` to `.env` and let Node inject it:
+
+```sh
+node --env-file=.env dist/main.cjs journey "Find the pricing page" --domain example.com
+```
+
+## Environment variables
+
+All configuration is environment-first: the consumer defines the variables, the CLI only reads them.
+
+| Var | Used by | Default | Purpose |
+|---|---|---|---|
+| `ORA_API_URL` | audit | `https://ora.ai` | Public scan API base (no auth) |
+| `ORA_PLATFORM_URL` | journey | `https://api.staging.agentfront.sh` | Authenticated platform API base |
+| `ORA_API_KEY` | journey | — (required) | Secret key (`ora_sk_…`), exchanged for a short-lived bearer token |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | audit: scan ok (and ≥ `--min-score` if set) · journey: run outcome `success` |
+| `1` | audit: score below `--min-score` · journey: run finished with a non-success outcome |
+| `2` | any error (bad flag value, API failure, timeout) |
+
+## Development
+
+```sh
+pnpm install
+pnpm test            # vitest (watch)
+pnpm test:ci         # single run + coverage
+pnpm typecheck
+pnpm lint
+pnpm build           # tsup → dist/main.cjs (single self-contained binary)
+node dist/main.cjs audit https://example.com
+```
+
+Manual testing without burning the live scan rate limit:
+
+```sh
+node scripts/mock-scan-server.mjs &
+ORA_API_URL=http://localhost:8799 node dist/main.cjs audit https://stripe.com
+```
+
+To exercise the published-package experience locally: `npm pack`, then `npx ./ora-ai-ax-0.1.0.tgz audit https://example.com`, or `pnpm link --global` and use `ax` directly.
+
+## License
+
+MIT

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"lineWidth": 100
+	},
+	"files": {
+		"ignore": ["dist/", "node_modules/", "coverage/", ".context/"]
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,55 @@
+{
+	"name": "@ora-ai/ax",
+	"version": "0.1.0",
+	"description": "Score any site's agent readiness and watch real AI agents navigate it — powered by ora",
+	"type": "module",
+	"packageManager": "pnpm@10.34.5",
+	"bin": {
+		"ax": "./dist/main.cjs"
+	},
+	"files": ["dist", ".env.example"],
+	"engines": {
+		"node": ">=20.0.0"
+	},
+	"scripts": {
+		"build": "rm -rf dist && tsup",
+		"test": "vitest",
+		"test:ci": "vitest run --coverage",
+		"lint": "biome check .",
+		"lint:fix": "biome check --write .",
+		"typecheck": "tsc --noEmit",
+		"prepublishOnly": "npm run build"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.9",
+		"@types/node": "^22",
+		"@vitest/coverage-v8": "^3",
+		"citty": "^0.1",
+		"picocolors": "^1",
+		"tsup": "^8",
+		"typescript": "^5.8",
+		"vitest": "^3"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild"]
+	},
+	"license": "MIT",
+	"homepage": "https://ora.ai",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/eralabs-ai/ora-cli.git"
+	},
+	"keywords": [
+		"ai",
+		"agents",
+		"agent-readiness",
+		"agent-experience",
+		"llms.txt",
+		"ora",
+		"cli",
+		"audit"
+	]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2162 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9
+        version: 1.9.4
+      '@types/node':
+        specifier: ^22
+        version: 22.20.1
+      '@vitest/coverage-v8':
+        specifier: ^3
+        version: 3.2.7(vitest@3.2.7(@types/node@22.20.1))
+      citty:
+        specifier: ^0.1
+        version: 0.1.6
+      picocolors:
+        specifier: ^1
+        version: 1.1.1
+      tsup:
+        specifier: ^8
+        version: 8.5.1(postcss@8.5.26)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.8
+        version: 5.9.3
+      vitest:
+        specifier: ^3
+        version: 3.2.7(@types/node@22.20.1)
+
+packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@vitest/coverage-v8@3.2.7':
+    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
+    peerDependencies:
+      '@vitest/browser': 3.2.7
+      vitest: 3.2.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/node@22.20.1))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.7(@types/node@22.20.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@22.20.1))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@22.20.1)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  acorn@8.18.0: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.62.4
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
+  minipass@7.1.3: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.18: {}
+
+  object-assign@4.1.1: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.26):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.26
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.6
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(postcss@8.5.26)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.26)
+      resolve-from: 5.0.0
+      rollup: 4.62.4
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.26
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@3.2.4(@types/node@22.20.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@22.20.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@22.20.1):
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+
+  vitest@3.2.7(@types/node@22.20.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@22.20.1))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@22.20.1)
+      vite-node: 3.2.4(@types/node@22.20.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0

--- a/scripts/mock-scan-server.mjs
+++ b/scripts/mock-scan-server.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// Tiny local stand-in for ora's public scan API, for manual CLI testing without
+// burning the live rate limit (10 scans/min/IP):
+//
+//   node scripts/mock-scan-server.mjs [port]         # default 8799
+//   ORA_API_URL=http://localhost:8799 node dist/main.cjs audit https://stripe.com
+//
+// Serves:
+//   GET /api/scan/stream?domain=X  data-only SSE: progress events, scan_complete
+//                                  (result nested under `result`), then summary_ready
+//   GET /api/score/:domain         the same ScanResult as plain JSON
+//
+// Drop a real captured ScanResult at scripts/fixtures/score.json to serve that
+// instead of the built-in sample.
+
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PORT = Number(process.argv[2] ?? 8799);
+
+const SAMPLE = {
+	domain: "stripe.com",
+	url: "https://stripe.com",
+	score: 71,
+	grade: "B",
+	analysisStatus: "complete",
+	pendingChecks: [],
+	agenticSummary:
+		"Stripe offers strong developer resource discoverability, but lacks an OpenAPI specification and a markdown sitemap.",
+	layers: [
+		{
+			id: "discovery",
+			name: "Discovery",
+			score: 14,
+			maxScore: 20,
+			checks: [
+				{
+					id: "llms-txt",
+					name: "llms.txt",
+					status: "pass",
+					score: 10,
+					maxScore: 10,
+					details: "found (2 KB)",
+				},
+				{
+					id: "sitemap-md",
+					name: "sitemap.md",
+					status: "fail",
+					score: 0,
+					maxScore: 6,
+					details: "status 404",
+					recommendation: "Publish /sitemap.md listing your key pages as markdown links",
+					estScoreGain: 2.4,
+				},
+				{
+					id: "robots-txt",
+					name: "robots.txt",
+					status: "warning",
+					score: 2,
+					maxScore: 4,
+					details: "partially restricted for AI crawlers",
+					recommendation: "Allow AI crawlers (GPTBot, ClaudeBot, PerplexityBot) in robots.txt",
+					estScoreGain: 1.2,
+				},
+				{
+					id: "mcp",
+					name: "MCP server",
+					status: "na",
+					score: 0,
+					maxScore: 2,
+					details: "not applicable for this URL kind",
+				},
+			],
+		},
+		{
+			id: "access",
+			name: "Access",
+			score: 12,
+			maxScore: 15,
+			checks: [
+				{
+					id: "markdown",
+					name: "Markdown content",
+					status: "pass",
+					score: 8,
+					maxScore: 8,
+					details: "text/markdown served to agents",
+				},
+				{
+					id: "openapi",
+					name: "OpenAPI spec",
+					status: "fail",
+					score: 0,
+					maxScore: 7,
+					details: "no /openapi.json or /openapi.yaml found",
+					recommendation: "Publish an OpenAPI specification at a well-known path",
+					estScoreGain: 3.1,
+				},
+			],
+		},
+	],
+};
+
+function loadResult() {
+	try {
+		const p = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "score.json");
+		return JSON.parse(readFileSync(p, "utf8"));
+	} catch {
+		return SAMPLE;
+	}
+}
+
+const sse = (obj) => `data: ${JSON.stringify(obj)}\n\n`;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const server = createServer(async (req, res) => {
+	const url = new URL(req.url, `http://localhost:${PORT}`);
+	const result = loadResult();
+
+	if (url.pathname === "/api/scan/stream") {
+		res.writeHead(200, {
+			"content-type": "text/event-stream",
+			"cache-control": "no-cache",
+			connection: "keep-alive",
+		});
+		const roster = result.layers.flatMap((l) => l.checks.map((c) => c.id));
+		res.write(sse({ type: "kind_detecting" }));
+		await sleep(150);
+		res.write(sse({ type: "kind_detected", kind: "domain" }));
+		await sleep(150);
+		res.write(sse({ type: "scan_init", checkRoster: roster, layerMaxScores: {} }));
+		res.write(sse({ type: "discovery_phase", label: "Crawling entry points…" }));
+		for (const [i, id] of roster.entries()) {
+			await sleep(120);
+			res.write(sse({ type: "check_complete", checkName: id, status: "pass", index: i }));
+		}
+		await sleep(150);
+		res.write(sse({ type: "scan_complete", result }));
+		await sleep(400); // the summary really does arrive after scan_complete
+		res.write(sse({ type: "summary_ready", agenticSummary: result.agenticSummary }));
+		res.end();
+		return;
+	}
+
+	if (url.pathname.startsWith("/api/score/")) {
+		res.writeHead(200, { "content-type": "application/json" });
+		res.end(JSON.stringify(result));
+		return;
+	}
+
+	res.writeHead(404, { "content-type": "application/json" });
+	res.end(JSON.stringify({ error: "not found" }));
+});
+
+server.listen(PORT, () => {
+	console.log(`mock ora scan API on http://localhost:${PORT}`);
+	console.log(
+		`try: ORA_API_URL=http://localhost:${PORT} node dist/main.cjs audit https://stripe.com`,
+	);
+});

--- a/src/api/platform.test.ts
+++ b/src/api/platform.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type RawRunStep, decodeEventBlock, launchJourney } from "./platform";
+
+// The run stream is *named* SSE — `event: X` + `data: {json}` blocks with
+// `: ping` heartbeat comments in between. A different framing from the scan
+// stream on purpose; the decoders must never be shared.
+const runStream = (events: Array<[string, unknown]>): Response =>
+	new Response(
+		events
+			.map(([name, data]) => `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`)
+			.join(": ping\n\n"),
+		{ status: 200, headers: { "content-type": "text/event-stream" } },
+	);
+
+const asJson = (body: unknown, status = 200): Response =>
+	new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+
+// Answers the platform's four endpoints: token exchange, run create, stream, list.
+function platformMock(config: { created?: unknown; stream?: Response; spendRows?: unknown[] }) {
+	return vi.fn(async (url: string | URL, init?: { method?: string }) => {
+		const at = String(url);
+		if (at.endsWith("/auth/token")) {
+			return asJson({ token: "jwt.test", expiresIn: 900, tokenType: "Bearer" });
+		}
+		if (at.endsWith("/experiment/v1/runs") && init?.method === "POST") {
+			return asJson(
+				config.created ?? {
+					runId: "run_9",
+					status: "pending",
+					streamUrl: "/experiment/v1/runs/run_9/stream",
+				},
+			);
+		}
+		if (at.includes("/runs?pageSize=")) return asJson({ results: config.spendRows ?? [] });
+		if (at.includes("/stream") && config.stream) return config.stream;
+		return asJson({});
+	});
+}
+
+const REQUEST = {
+	intent: "Locate the REST API reference",
+	domain: "acme.dev",
+	harness: "claude-code",
+	apiKey: "ora_sk_local",
+	baseUrl: "https://platform.test",
+};
+
+const FINALE: Array<[string, unknown]> = [
+	[
+		"result",
+		{ runId: "run_9", outcome: "success", result: { run_id: "run_9", outcome: "success" } },
+	],
+	["insight", { runId: "run_9", insight: { visibility_score: 77 } }],
+];
+
+describe("decodeEventBlock", () => {
+	it("reads the event name and payload", () => {
+		expect(decodeEventBlock('event: result\ndata: {"ok":1}')).toEqual({
+			event: "result",
+			data: '{"ok":1}',
+		});
+	});
+
+	it("ignores heartbeat comments", () => {
+		expect(decodeEventBlock(": ping")).toBeNull();
+	});
+
+	it("defaults to 'message' and concatenates data lines", () => {
+		expect(decodeEventBlock("data: one\ndata: two")).toEqual({
+			event: "message",
+			data: "one\ntwo",
+		});
+	});
+});
+
+describe("launchJourney", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	it("walks the whole pipeline: token → create → stream → spend", async () => {
+		const fetchMock = platformMock({
+			stream: runStream([
+				["run", { runId: "run_9" }],
+				[
+					"trajectory",
+					{ steps: [{ id: 0, turn: 1, type: "text", kind: "reasoning", thinking: "…" }] },
+				],
+				["step", { runId: "run_9", seq: 1, step: { type: "thinking", turn: 1, thinking: "…" } }],
+				[
+					"step",
+					{ runId: "run_9", seq: 2, step: { type: "tool_call", turn: 2, tool: "WebSearch" } },
+				],
+				...FINALE,
+			]),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const burst: RawRunStep[] = [];
+		const run = await launchJourney(REQUEST, { step: (s) => burst.push(s) });
+
+		// Raw `step` events are the end-of-run burst — collected, never merged
+		// with trajectory snapshots.
+		expect(run.steps).toHaveLength(2);
+		expect(burst).toHaveLength(2);
+		expect(run.steps[1]).toMatchObject({ type: "tool_call", tool: "WebSearch" });
+		expect(run.result?.outcome).toBe("success");
+		expect(run.insight?.visibility_score).toBe(77);
+
+		expect(fetchMock).toHaveBeenCalledTimes(4);
+		expect(String(fetchMock.mock.calls[0][0])).toContain("/auth/token");
+		expect(String(fetchMock.mock.calls[2][0])).toContain("/experiment/v1/runs/run_9/stream");
+		expect(String(fetchMock.mock.calls[3][0])).toContain("/runs?pageSize=");
+	});
+
+	it("relays every growing trajectory snapshot and keeps the last", async () => {
+		const one = [{ id: 0, turn: 1, type: "text", kind: "reasoning", thinking: "look" }];
+		const two = [
+			...one,
+			{ id: 1, turn: 2, type: "tool_call", tool: "WebSearch", input_display: "acme docs" },
+		];
+		vi.stubGlobal(
+			"fetch",
+			platformMock({
+				stream: runStream([
+					["run", { runId: "run_9" }],
+					["trajectory", { steps: one }],
+					["trajectory", { steps: two }],
+					...FINALE,
+				]),
+			}),
+		);
+
+		const sizes: number[] = [];
+		const run = await launchJourney(REQUEST, { snapshot: (s) => sizes.push(s.length) });
+		expect(sizes).toEqual([1, 2]);
+		expect(run.trajectory).toHaveLength(2);
+		expect(run.trajectory[1]).toMatchObject({ type: "tool_call", tool: "WebSearch" });
+	});
+
+	it("reads tokens and cost off the runs list after the stream", async () => {
+		vi.stubGlobal(
+			"fetch",
+			platformMock({
+				stream: runStream(FINALE),
+				spendRows: [
+					{ id: "someone_else", total_tokens: 5, cost_usd: 9.9 },
+					{
+						id: "run_9",
+						total_tokens: 119_100,
+						input_tokens: 101_000,
+						output_tokens: 4_100,
+						cost_usd: 0.031,
+					},
+				],
+			}),
+		);
+
+		const run = await launchJourney(REQUEST);
+		expect(run.usage).toMatchObject({
+			totalTokens: 119_100,
+			inputTokens: 101_000,
+			outputTokens: 4_100,
+			costUsd: 0.031,
+		});
+	});
+
+	it("fires `opened` exactly once, ignoring the stream's own run event", async () => {
+		vi.stubGlobal(
+			"fetch",
+			platformMock({ stream: runStream([["run", { runId: "run_9" }], ...FINALE]) }),
+		);
+		const openings: string[] = [];
+		await launchJourney(REQUEST, { opened: (id) => openings.push(id) });
+		expect(openings).toEqual(["run_9"]);
+	});
+
+	it("posts exactly the provided run parameters", async () => {
+		const fetchMock = platformMock({ stream: runStream(FINALE) });
+		vi.stubGlobal("fetch", fetchMock);
+
+		await launchJourney({ ...REQUEST, model: "claude-haiku-4-5-20251001" });
+		const create = fetchMock.mock.calls.find(
+			([at, init]) =>
+				String(at).endsWith("/experiment/v1/runs") &&
+				(init as { method?: string })?.method === "POST",
+		);
+		expect(JSON.parse((create?.[1] as { body: string }).body)).toEqual({
+			intent: "Locate the REST API reference",
+			domain: "acme.dev",
+			harness: "claude-code",
+			model: "claude-haiku-4-5-20251001",
+		});
+	});
+
+	it("demands ORA_API_KEY up front", async () => {
+		vi.stubEnv("ORA_API_KEY", "");
+		await expect(
+			launchJourney({ intent: "x", harness: "claude-code", baseUrl: "https://platform.test" }),
+		).rejects.toThrow(/ORA_API_KEY/);
+	});
+
+	it("translates a 401 token exchange into a key hint", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("{}", { status: 401 })),
+		);
+		await expect(launchJourney(REQUEST)).rejects.toThrow(/API key/i);
+	});
+
+	it("translates a 429 on create into a rate-limit hint", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string | URL) => {
+				if (String(url).endsWith("/auth/token")) return asJson({ token: "t" });
+				return new Response("{}", { status: 429 });
+			}),
+		);
+		await expect(launchJourney(REQUEST)).rejects.toThrow(/rate limit/i);
+	});
+
+	it("times out when the run stream goes silent", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string | URL, init?: { signal?: AbortSignal }) => {
+				if (String(url).endsWith("/auth/token")) return asJson({ token: "t" });
+				if (String(url).endsWith("/experiment/v1/runs")) {
+					return asJson({ runId: "run_9", status: "pending", streamUrl: "/x/stream" });
+				}
+				const silent = new ReadableStream<Uint8Array>({
+					start(controller) {
+						init?.signal?.addEventListener("abort", () => controller.error(new Error("aborted")));
+					},
+				});
+				return new Response(silent, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}),
+		);
+		await expect(launchJourney({ ...REQUEST, idleMs: 40 })).rejects.toThrow(/timed out/i);
+	});
+});

--- a/src/api/platform.ts
+++ b/src/api/platform.ts
@@ -1,0 +1,420 @@
+import { pause, watchdog } from "./shared";
+
+// Client for ora's authenticated platform API — the machinery behind `journey`.
+// One journey == one run: an agent harness pursuing an intent against a domain.
+// (The separate POST /studio/v1/journeys endpoint is a server-side multi-agent
+// fan-out needing the journeys:write scope; a runs:read + runs:write key is all
+// this client requires, so it stays away from that endpoint on purpose.)
+
+const PLATFORM_BASE = "https://api.staging.agentfront.sh";
+const RUN_IDLE_MS = 120_000; // agents legitimately go quiet between turns
+
+// --- Wire shapes ---
+
+export interface RunSummary {
+	run_id: string;
+	domain?: string;
+	intent?: string;
+	harness?: string;
+	model?: string;
+	effective_model?: string;
+	outcome: string;
+	num_turns?: number;
+	duration_ms?: number;
+	started_at?: string;
+	finished_at?: string;
+	last_seq?: number;
+}
+
+export interface InsightRecommendation {
+	title: string;
+	detail: string;
+	priority?: string;
+}
+
+export interface JourneyInsight {
+	summary?: string;
+	outcome?: string;
+	visibility_score?: number;
+	intent_satisfied?: boolean;
+	task_satisfied?: string;
+	key_observations?: string[];
+	friction_points?: string[];
+	recommendations?: InsightRecommendation[];
+	intent_category?: string;
+	journey_layers?: string[];
+	/** Usage of the analyzer that produced the insight — not the run itself. */
+	usage?: { input_tokens?: number; output_tokens?: number };
+}
+
+/**
+ * One entry of a `trajectory` snapshot. Richer than the raw `step` events: a
+ * tool call arrives merged with its result (status, duration, structured
+ * output) plus ora's attribution of where the agent got the target from.
+ */
+export interface JourneyStep {
+	id: number;
+	turn: number;
+	type: string; // "text" | "tool_call" | "tool_result" | …
+	kind?: string; // for text steps: "reasoning" | "text" | "output"
+	text?: string;
+	thinking?: string;
+	tool?: string;
+	action?: string;
+	input?: Record<string, unknown>;
+	input_display?: string;
+	summary?: string;
+	label?: string;
+	status?: number;
+	duration_ms?: number;
+	is_error?: boolean;
+	output_structured?: { body?: string; links?: Array<{ title?: string; url?: string }> };
+	elapsed_ms?: number;
+	attribution?: {
+		kind?: string; // "web_search" | "prior_knowledge" | "previous_artifact" | …
+		method?: string;
+		confidence?: string;
+		/** For link-follows: the exact step this URL was discovered on. */
+		referrer?: { step_id?: number; turn?: number; artifact_kind?: string; url_path?: string };
+	};
+}
+
+/** A raw `step` event payload (loosely typed; the CLI never renders from these). */
+export interface RawRunStep {
+	type: string;
+	turn?: number;
+	tool?: string;
+	[extra: string]: unknown;
+}
+
+/** Run-level token/cost totals, read from the runs list after completion. */
+export interface RunSpend {
+	totalTokens?: number;
+	inputTokens?: number;
+	outputTokens?: number;
+	cacheReadTokens?: number;
+	cacheCreationTokens?: number;
+	costUsd?: number;
+}
+
+export interface JourneyHooks {
+	/** Fired exactly once when the run exists (the stream's own `run` event is ignored). */
+	opened?: (runId: string) => void;
+	/**
+	 * A full-trajectory snapshot arrived. These flow every few seconds while
+	 * the agent works and are the ONLY live signal — drive all UI from here.
+	 */
+	snapshot?: (steps: JourneyStep[]) => void;
+	/**
+	 * A raw `step` event arrived. ⚠ The server flushes these in one burst at
+	 * the very end of the run; rendering from them means a blank screen until
+	 * the agent finishes.
+	 */
+	step?: (step: RawRunStep, seq: number) => void;
+	finished?: (summary: RunSummary) => void;
+	scored?: (insight: JourneyInsight) => void;
+}
+
+export interface RunRequest {
+	intent: string;
+	domain?: string;
+	harness?: string;
+	model?: string;
+	/** "harness" = tool-using agent (default); "direct" = single LLM answer. */
+	executionKind?: "harness" | "direct";
+	baseUrl?: string;
+	apiKey?: string;
+	idleMs?: number;
+}
+
+export interface JourneyRun {
+	runId: string;
+	intent: string;
+	domain?: string;
+	harness?: string;
+	result?: RunSummary;
+	insight?: JourneyInsight;
+	usage?: RunSpend;
+	steps: RawRunStep[];
+	/** The last trajectory snapshot seen — the definitive step list. */
+	trajectory: JourneyStep[];
+}
+
+// --- Auth ---
+// The ora_sk_ secret goes in the authorization HEADER (never the body) and is
+// exchanged for a ~15-minute bearer token used on every later call.
+
+async function exchangeKey(base: string, secret: string): Promise<string> {
+	const res = await fetch(`${base}/auth/token`, {
+		method: "POST",
+		headers: { authorization: `Bearer ${secret}`, "content-type": "application/json" },
+		body: "{}",
+	});
+	if (res.status === 401) throw new Error("ora rejected the API key (401). Check ORA_API_KEY.");
+	const payload = (await res.json().catch(() => ({}))) as { token?: string; error?: string };
+	if (!res.ok || !payload.token) {
+		throw new Error(`ora auth failed (${res.status})${payload.error ? `: ${payload.error}` : ""}`);
+	}
+	return payload.token;
+}
+
+// --- Run creation ---
+
+interface CreatedRun {
+	runId: string;
+	status: string;
+	streamUrl?: string;
+	answer?: string;
+}
+
+async function createRun(base: string, bearer: string, request: RunRequest): Promise<CreatedRun> {
+	const body: Record<string, unknown> = { intent: request.intent };
+	if (request.domain) body.domain = request.domain;
+	if (request.harness) body.harness = request.harness;
+	if (request.model) body.model = request.model;
+	if (request.executionKind) body.execution_kind = request.executionKind;
+
+	const res = await fetch(`${base}/experiment/v1/runs`, {
+		method: "POST",
+		headers: { authorization: `Bearer ${bearer}`, "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+	if (res.status === 429) throw new Error("ora rate limit hit (429). Wait a moment and retry.");
+
+	const text = await res.text();
+	let created: CreatedRun & { error?: string; message?: string };
+	try {
+		created = JSON.parse(text);
+	} catch {
+		throw new Error(`ora returned a non-JSON response (${res.status})`);
+	}
+	if (!res.ok || !created.runId) {
+		throw new Error(`ora run failed (${res.status}): ${created.message ?? created.error ?? text}`);
+	}
+	return created;
+}
+
+// --- The run stream ---
+// Named SSE (`event: X` + `data: {json}` + `: ping` heartbeats) — a different
+// framing from the scan stream, so it gets its own decoder. Expected order:
+// run → trajectory×N → step×N (end burst) → result → insight. The insight is
+// delivered in-stream a few seconds after the result; no polling needed.
+
+export function decodeEventBlock(block: string): { event: string; data: string } | null {
+	let event = "message";
+	const payload: string[] = [];
+	for (const row of block.split("\n")) {
+		if (row.startsWith(":")) continue; // heartbeat comment
+		if (row.startsWith("event:")) event = row.slice(6).trim();
+		else if (row.startsWith("data:")) payload.push(row.slice(5).replace(/^ /, ""));
+	}
+	return payload.length ? { event, data: payload.join("\n") } : null;
+}
+
+interface StreamedRun {
+	summary?: RunSummary;
+	insight?: JourneyInsight;
+	steps: RawRunStep[];
+	trajectory: JourneyStep[];
+}
+
+async function followRunStream(
+	base: string,
+	bearer: string,
+	streamPath: string,
+	hooks: JourneyHooks,
+	idleMs: number,
+): Promise<StreamedRun> {
+	const target = streamPath.startsWith("http") ? streamPath : `${base}${streamPath}`;
+	const dog = watchdog(idleMs);
+
+	const res = await fetch(target, {
+		headers: { authorization: `Bearer ${bearer}`, accept: "text/event-stream" },
+		signal: dog.signal,
+	});
+	if (!res.ok || !res.body) {
+		dog.disarm();
+		throw new Error(`ora run stream failed (${res.status})`);
+	}
+
+	const utf8 = new TextDecoder();
+	const collected: StreamedRun = { steps: [], trajectory: [] };
+	let pending = "";
+
+	try {
+		streaming: for await (const chunk of res.body) {
+			dog.poke();
+			pending = `${pending}${utf8.decode(chunk as Uint8Array, { stream: true })}`.replace(
+				/\r\n?/g,
+				"\n",
+			);
+			let cut = pending.indexOf("\n\n");
+			while (cut !== -1) {
+				const decoded = decodeEventBlock(pending.slice(0, cut));
+				pending = pending.slice(cut + 2);
+				cut = pending.indexOf("\n\n");
+				if (!decoded) continue;
+				let payload: Record<string, unknown>;
+				try {
+					payload = JSON.parse(decoded.data);
+				} catch {
+					continue;
+				}
+				absorb(collected, decoded.event, payload, hooks);
+				if (collected.summary && collected.insight) break streaming;
+			}
+		}
+	} catch (cause) {
+		if (dog.tripped()) throw new Error(`ora run stream timed out after ${idleMs}ms of silence`);
+		throw cause;
+	} finally {
+		dog.disarm();
+		res.body.cancel().catch(() => {});
+	}
+
+	return collected;
+}
+
+function absorb(
+	into: StreamedRun,
+	event: string,
+	payload: Record<string, unknown>,
+	hooks: JourneyHooks,
+): void {
+	switch (event) {
+		case "trajectory": {
+			const snapshot = payload.steps;
+			if (Array.isArray(snapshot)) {
+				into.trajectory = snapshot as JourneyStep[];
+				hooks.snapshot?.(into.trajectory);
+			}
+			return;
+		}
+		case "step": {
+			const step = payload.step as RawRunStep | undefined;
+			if (step) {
+				into.steps.push(step);
+				hooks.step?.(step, Number(payload.seq ?? into.steps.length));
+			}
+			return;
+		}
+		case "result": {
+			const summary = payload.result as RunSummary | undefined;
+			if (summary) {
+				into.summary = summary;
+				hooks.finished?.(summary);
+			}
+			return;
+		}
+		case "insight": {
+			const insight = payload.insight as JourneyInsight | undefined;
+			if (insight) {
+				into.insight = insight;
+				hooks.scored?.(insight);
+			}
+			return;
+		}
+		default:
+			// `run` merely repeats the id we already hold; ping comments never get here.
+			return;
+	}
+}
+
+// --- Spend lookup ---
+// Tokens and cost never ride the stream; they land on the runs list, and the
+// pricing itself is written asynchronously — hence the single delayed retry.
+
+interface SpendRow {
+	id: string;
+	total_tokens?: number | null;
+	input_tokens?: number | null;
+	output_tokens?: number | null;
+	cache_read_tokens?: number | null;
+	cache_creation_tokens?: number | null;
+	cost_usd?: number | null;
+}
+
+async function readRunSpend(
+	base: string,
+	bearer: string,
+	runId: string,
+): Promise<RunSpend | undefined> {
+	for (let attempt = 0; ; attempt++) {
+		let row: SpendRow | undefined;
+		try {
+			const res = await fetch(`${base}/experiment/v1/runs?pageSize=50`, {
+				headers: { authorization: `Bearer ${bearer}` },
+			});
+			if (!res.ok) return undefined;
+			const page = (await res.json()) as { results?: SpendRow[] };
+			row = page.results?.find((entry) => entry.id === runId);
+		} catch {
+			return undefined;
+		}
+		if (!row) return undefined;
+		if (row.total_tokens != null || row.cost_usd != null) {
+			return {
+				totalTokens: row.total_tokens ?? undefined,
+				inputTokens: row.input_tokens ?? undefined,
+				outputTokens: row.output_tokens ?? undefined,
+				cacheReadTokens: row.cache_read_tokens ?? undefined,
+				cacheCreationTokens: row.cache_creation_tokens ?? undefined,
+				costUsd: row.cost_usd ?? undefined,
+			};
+		}
+		if (attempt > 0) return undefined;
+		await pause(1200);
+	}
+}
+
+// --- Orchestration: key → token → create → stream → spend ---
+
+export async function launchJourney(
+	request: RunRequest,
+	hooks: JourneyHooks = {},
+): Promise<JourneyRun> {
+	const base = (request.baseUrl ?? process.env.ORA_PLATFORM_URL ?? PLATFORM_BASE).replace(
+		/\/+$/,
+		"",
+	);
+	const secret = request.apiKey ?? process.env.ORA_API_KEY;
+	if (!secret) {
+		throw new Error(
+			"Missing ORA_API_KEY. Set it in your environment or a local .env file (see .env.example).",
+		);
+	}
+
+	const bearer = await exchangeKey(base, secret);
+	const created = await createRun(base, bearer, request);
+
+	const outline = {
+		runId: created.runId,
+		intent: request.intent,
+		domain: request.domain,
+		harness: request.harness,
+	};
+
+	// Rare synchronous completion: no stream to follow, return the bare record.
+	if (created.status === "succeeded" && !created.streamUrl) {
+		return { ...outline, steps: [], trajectory: [] };
+	}
+
+	hooks.opened?.(created.runId);
+	const streamed = await followRunStream(
+		base,
+		bearer,
+		created.streamUrl ?? `/experiment/v1/runs/${created.runId}/stream`,
+		hooks,
+		request.idleMs ?? RUN_IDLE_MS,
+	);
+	const spend = streamed.summary ? await readRunSpend(base, bearer, created.runId) : undefined;
+
+	return {
+		...outline,
+		result: streamed.summary,
+		insight: streamed.insight,
+		usage: spend,
+		steps: streamed.steps,
+		trajectory: streamed.trajectory,
+	};
+}

--- a/src/api/scan.test.ts
+++ b/src/api/scan.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type ScanResult, performScan } from "./scan";
+
+// The scan stream is data-only SSE: every block is just `data: {json}` with a
+// `type` field inside — no `event:` names.
+const scanStream = (events: unknown[]): Response =>
+	new Response(events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(""), {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+
+const asJson = (body: unknown, status = 200): Response =>
+	new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+
+const settled = (extra: Partial<ScanResult> = {}): ScanResult => ({
+	domain: "acme.dev",
+	score: 88,
+	analysisStatus: "complete",
+	pendingChecks: [],
+	layers: [],
+	...extra,
+});
+
+describe("performScan", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	it("resolves with the payload nested in scan_complete", async () => {
+		const seen: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string | URL) => {
+				seen.push(String(url));
+				return scanStream([
+					{ type: "kind_detected", kind: "domain" },
+					{ type: "scan_complete", result: settled() },
+				]);
+			}),
+		);
+
+		const scan = await performScan("acme.dev");
+		expect(scan.score).toBe(88);
+		expect(seen).toEqual(["https://ora.ai/api/scan/stream?domain=acme.dev"]);
+	});
+
+	it("keeps reading past scan_complete to pick up summary_ready", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				scanStream([
+					{ type: "scan_complete", result: settled() },
+					{ type: "summary_ready", agenticSummary: "Solid entry points, weak specs." },
+				]),
+			),
+		);
+
+		const scan = await performScan("acme.dev");
+		expect(scan.agenticSummary).toBe("Solid entry points, weak specs.");
+	});
+
+	it("reports one-line progress through the phases of a scan", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				scanStream([
+					{ type: "kind_detecting" },
+					{ type: "kind_detected", kind: "domain" },
+					{ type: "scan_init", checkRoster: ["a", "b"], layerMaxScores: {} },
+					{ type: "discovery_phase", label: "Crawling entry points…" },
+					{ type: "check_complete", checkName: "llms.txt" },
+					{ type: "check_complete", checkName: "robots.txt" },
+					{ type: "scan_complete", result: settled() },
+				]),
+			),
+		);
+
+		const lines: string[] = [];
+		await performScan("acme.dev", { progress: (line) => lines.push(line) });
+		expect(lines[0]).toBe("Scanning acme.dev with ora");
+		expect(lines).toContain("Detecting URL kind…");
+		expect(lines).toContain("Detected domain, scanning…");
+		expect(lines).toContain("Crawling entry points…");
+		// determinate bar once the roster size is known
+		expect(lines.find((l) => l.includes("1/2"))).toMatch(/█+░+ 1\/2 · llms\.txt/);
+		expect(lines.at(-1)).toBe("Finishing up…");
+	});
+
+	it("rejects when the stream closes without scan_complete", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => scanStream([{ type: "check_complete" }, { type: "layer_complete" }])),
+		);
+		await expect(performScan("acme.dev")).rejects.toThrow(/ended before completing/i);
+	});
+
+	it("polls the score endpoint while analysis is partial", async () => {
+		const halfway = settled({ score: 51, analysisStatus: "partial", pendingChecks: ["crawl"] });
+		const finished = settled({ score: 83 });
+		const seen: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string | URL) => {
+				seen.push(String(url));
+				return seen.length === 1
+					? scanStream([{ type: "scan_complete", result: halfway }])
+					: asJson(finished);
+			}),
+		);
+
+		const scan = await performScan("acme.dev", { pollEveryMs: 0 });
+		expect(scan.score).toBe(83);
+		expect(scan.analysisStatus).toBe("complete");
+		expect(seen).toHaveLength(2);
+		expect(seen[0]).toContain("/api/scan/stream");
+		expect(seen[1]).toBe("https://ora.ai/api/score/acme.dev");
+	});
+
+	it("gives up polling once the analysis is marked stuck", async () => {
+		const halfway = settled({ score: 40, analysisStatus: "partial", pendingChecks: ["crawl"] });
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(scanStream([{ type: "scan_complete", result: halfway }]))
+			.mockResolvedValueOnce(asJson(settled({ score: 40, analysisStatus: "stuck" })));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const scan = await performScan("acme.dev", { pollEveryMs: 0, pollLimit: 25 });
+		expect(scan.analysisStatus).toBe("stuck");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("explains the public rate limit on 429", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("{}", { status: 429, headers: { "retry-after": "42" } })),
+		);
+		await expect(performScan("acme.dev")).rejects.toThrow(/rate limit.*42s/i);
+	});
+
+	it("surfaces the server's message on a 4xx response", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => asJson({ error: "Bad", message: "Domain failed validation" }, 400)),
+		);
+		await expect(performScan("not a domain")).rejects.toThrow(/Domain failed validation/);
+	});
+
+	it("times out when the stream goes silent", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_url: string | URL, init?: { signal?: AbortSignal }) => {
+				// Connects but never emits; only the idle watchdog can end this.
+				const silent = new ReadableStream<Uint8Array>({
+					start(controller) {
+						init?.signal?.addEventListener("abort", () => controller.error(new Error("aborted")));
+					},
+				});
+				return new Response(silent, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}),
+		);
+		await expect(performScan("acme.dev", { idleMs: 40 })).rejects.toThrow(/timed out/i);
+	});
+});

--- a/src/api/scan.ts
+++ b/src/api/scan.ts
@@ -1,0 +1,265 @@
+import { errorBodyText, pause, watchdog } from "./shared";
+
+// Client for ora's public agent-readiness scan. Uses the SSE endpoint
+// (GET /api/scan/stream) rather than POST /api/scan: the synchronous variant
+// has a ~30s hard cap and reliably times out on large or uncached sites,
+// whereas the stream just keeps emitting while the scan works.
+
+const PUBLIC_BASE = "https://ora.ai";
+const STREAM_IDLE_MS = 60_000;
+const POLL_EVERY_MS = 2_000;
+const POLL_LIMIT = 45; // ≈90s of patience for async deep analysis
+const BAR_CELLS = 14;
+
+export type ScanCheckStatus = "pass" | "fail" | "warning" | "error" | "pending" | "na";
+
+export interface ScanCheck {
+	id: string;
+	name: string;
+	/** What the check inspects — not the remedy. */
+	description?: string;
+	status: ScanCheckStatus;
+	score: number;
+	maxScore: number;
+	/** The observed finding. */
+	details?: string;
+	/** The remedy to apply. Absent from ora's OpenAPI spec, present in responses. */
+	recommendation?: string;
+	/** Estimated points recovered by fixing this check. */
+	estScoreGain?: number;
+}
+
+export interface ScanLayer {
+	id: string;
+	name: string;
+	description?: string;
+	checks: ScanCheck[];
+	score: number;
+	maxScore: number;
+}
+
+export interface ScanResult {
+	domain?: string;
+	url?: string;
+	finalUrl?: string;
+	score: number;
+	maxScore?: number;
+	grade?: string;
+	analysisStatus?: "complete" | "partial" | "stuck";
+	pendingChecks?: string[];
+	layers?: ScanLayer[];
+	agenticSummary?: string;
+	urlKind?: string;
+	scannedAt?: string;
+	durationMs?: number;
+}
+
+export interface ScanOptions {
+	/** Receives one-line progress updates while the scan streams and polls. */
+	progress?: (line: string) => void;
+	/** Base URL override; otherwise $ORA_API_URL, otherwise https://ora.ai. */
+	baseUrl?: string;
+	/** Abort when the stream is silent for this long (default 60s). */
+	idleMs?: number;
+	pollEveryMs?: number;
+	pollLimit?: number;
+}
+
+/**
+ * Scan `target` and resolve with ora's full ScanResult. When the stream ends
+ * with analysis still marked partial, keeps polling GET /api/score/{domain}
+ * until it settles (complete or stuck) or the poll budget runs out.
+ */
+export async function performScan(target: string, options: ScanOptions = {}): Promise<ScanResult> {
+	const base = (options.baseUrl ?? process.env.ORA_API_URL ?? PUBLIC_BASE).replace(/\/+$/, "");
+	options.progress?.(`Scanning ${target} with ora`);
+
+	let scan = await consumeScanStream(base, target, options);
+	if (stillAnalyzing(scan)) scan = await awaitDeepAnalysis(base, scan, options);
+	return scan;
+}
+
+// The stream is data-only SSE: `data: {json}` blocks separated by blank lines,
+// no `event:` names. Every payload carries a `type` discriminator. Two of them
+// matter beyond progress: `scan_complete` (ScanResult nested under `result`)
+// and `summary_ready` (the one-line agentic verdict, generated after scoring —
+// stopping at scan_complete would silently drop it).
+async function consumeScanStream(
+	base: string,
+	target: string,
+	options: ScanOptions,
+): Promise<ScanResult> {
+	const idleMs = options.idleMs ?? STREAM_IDLE_MS;
+	const dog = watchdog(idleMs);
+	const timeoutError = () =>
+		new Error(`ora scan timed out — no progress for ${Math.round(idleMs / 1000)}s`);
+
+	let res: Response;
+	try {
+		res = await fetch(`${base}/api/scan/stream?domain=${encodeURIComponent(target)}`, {
+			headers: { accept: "text/event-stream" },
+			signal: dog.signal,
+		});
+	} catch (cause) {
+		dog.disarm();
+		if (dog.tripped()) throw timeoutError();
+		const detail = cause instanceof Error ? cause.message : String(cause);
+		throw new Error(`ora scan request failed: ${detail}`);
+	}
+
+	if (res.status === 429) {
+		dog.disarm();
+		const wait = res.headers.get("retry-after");
+		throw new Error(
+			`ora rate limit exceeded (10 scans/min per IP)${wait ? ` — retry after ${wait}s` : ""}`,
+		);
+	}
+	if (!res.ok || !res.body) {
+		dog.disarm();
+		throw new Error(`ora scan failed: ${await errorBodyText(res)}`);
+	}
+
+	const narrate = progressNarrator();
+	const utf8 = new TextDecoder();
+	let pending = "";
+	let scan: ScanResult | undefined;
+	let verdict: string | undefined;
+
+	try {
+		streaming: for await (const chunk of res.body) {
+			dog.poke();
+			pending = `${pending}${utf8.decode(chunk as Uint8Array, { stream: true })}`.replace(
+				/\r\n?/g,
+				"\n",
+			);
+			let cut = pending.indexOf("\n\n");
+			while (cut !== -1) {
+				const packet = joinDataLines(pending.slice(0, cut));
+				pending = pending.slice(cut + 2);
+				cut = pending.indexOf("\n\n");
+				if (!packet) continue;
+				let event: Record<string, unknown>;
+				try {
+					event = JSON.parse(packet);
+				} catch {
+					continue;
+				}
+				const line = narrate(event);
+				if (line) options.progress?.(line);
+				if (event.type === "scan_complete" && event.result) {
+					scan = event.result as ScanResult;
+				} else if (event.type === "summary_ready" && typeof event.agenticSummary === "string") {
+					verdict = event.agenticSummary;
+				}
+				// Bail as soon as both pieces are in hand; otherwise drain to the end
+				// (the server closes shortly after, with or without a summary).
+				if (scan && verdict) break streaming;
+			}
+		}
+	} catch (cause) {
+		if (dog.tripped()) throw timeoutError();
+		const detail = cause instanceof Error ? cause.message : String(cause);
+		throw new Error(`ora scan stream error: ${detail}`);
+	} finally {
+		dog.disarm();
+		res.body.cancel().catch(() => {});
+	}
+
+	if (!scan) throw new Error("ora scan stream ended before completing");
+	if (verdict && !scan.agenticSummary) scan.agenticSummary = verdict;
+	return scan;
+}
+
+// Concatenate the data: lines of one SSE block, dropping one optional leading
+// space per line (the scan stream never sends event: lines).
+function joinDataLines(block: string): string {
+	const collected: string[] = [];
+	for (const row of block.split("\n")) {
+		if (row.startsWith("data:")) collected.push(row.slice(5).replace(/^ /, ""));
+	}
+	return collected.join("\n");
+}
+
+// Turns raw stream events into spinner copy. The determinate bar is driven by
+// `check_complete` events against the roster announced in `scan_init`;
+// `check_start` is useless for progress because ora emits every start up
+// front. Completions can also overshoot the roster, hence the clamp.
+function progressNarrator(): (event: Record<string, unknown>) => string | undefined {
+	let expected = 0;
+	let finished = 0;
+	let checkName = "";
+
+	return (event) => {
+		switch (event.type) {
+			case "kind_detecting":
+				return "Detecting URL kind…";
+			case "kind_detected":
+				return typeof event.kind === "string" ? `Detected ${event.kind}, scanning…` : undefined;
+			case "scan_init":
+				if (Array.isArray(event.checkRoster)) expected = event.checkRoster.length;
+				return undefined;
+			case "discovery_phase":
+				return typeof event.label === "string" ? event.label : undefined;
+			case "check_complete": {
+				finished += 1;
+				if (typeof event.checkName === "string") checkName = event.checkName;
+				if (expected <= 0) return `Running checks… (${finished})`;
+				const capped = Math.min(finished, expected);
+				const cells = Math.min(BAR_CELLS, Math.max(0, Math.round((capped / expected) * BAR_CELLS)));
+				const bar = `${"█".repeat(cells)}${"░".repeat(BAR_CELLS - cells)}`;
+				return `${bar} ${capped}/${expected}${checkName ? ` · ${checkName}` : ""}`;
+			}
+			case "scan_complete":
+				return "Finishing up…";
+			default:
+				return undefined;
+		}
+	};
+}
+
+function stillAnalyzing(scan: ScanResult): boolean {
+	if (scan.analysisStatus === "complete" || scan.analysisStatus === "stuck") return false;
+	if (scan.analysisStatus === "partial") return true;
+	return (scan.pendingChecks?.length ?? 0) > 0;
+}
+
+async function awaitDeepAnalysis(
+	base: string,
+	first: ScanResult,
+	options: ScanOptions,
+): Promise<ScanResult> {
+	const host = first.domain ?? hostOf(first.url);
+	if (!host) return first;
+
+	const scoreUrl = `${base}/api/score/${encodeURIComponent(host)}`;
+	const every = options.pollEveryMs ?? POLL_EVERY_MS;
+	const limit = options.pollLimit ?? POLL_LIMIT;
+	let latest = first;
+
+	for (let round = 0; round < limit && stillAnalyzing(latest); round++) {
+		const left = latest.pendingChecks?.length ?? 0;
+		options.progress?.(
+			left ? `Analyzing… ${left} check${left === 1 ? "" : "s"} pending` : "Analyzing…",
+		);
+		await pause(every);
+		try {
+			const res = await fetch(scoreUrl, {
+				headers: { accept: "application/json" },
+				signal: AbortSignal.timeout(15_000),
+			});
+			if (res.ok) latest = (await res.json()) as ScanResult;
+		} catch {
+			// transient hiccup — keep polling until the round budget is spent
+		}
+	}
+	return latest;
+}
+
+function hostOf(url?: string): string | undefined {
+	if (!url) return undefined;
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return undefined;
+	}
+}

--- a/src/api/shared.ts
+++ b/src/api/shared.ts
@@ -1,0 +1,46 @@
+// Plumbing shared by both API clients. Note that the two ora streams do NOT
+// share an SSE parser: the scan stream is data-only JSON with a `type` field,
+// while the run stream uses named `event:` blocks with `: ping` heartbeats.
+// Each client owns its own decoder; only the timeout/error plumbing lives here.
+
+/**
+ * Idle watchdog for a long-lived stream: aborts the fetch when `poke()` hasn't
+ * been called for `ms`. Unlike a fixed deadline, a stream that keeps emitting
+ * can run indefinitely — which is what a slow-but-healthy scan or agent needs.
+ */
+export function watchdog(ms: number): {
+	signal: AbortSignal;
+	poke: () => void;
+	disarm: () => void;
+	tripped: () => boolean;
+} {
+	const controller = new AbortController();
+	let fired = false;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const poke = () => {
+		clearTimeout(timer);
+		timer = setTimeout(() => {
+			fired = true;
+			controller.abort();
+		}, ms);
+	};
+	poke();
+	return {
+		signal: controller.signal,
+		poke,
+		disarm: () => clearTimeout(timer),
+		tripped: () => fired,
+	};
+}
+
+/** Best-effort human message from an error response body. */
+export async function errorBodyText(res: Response): Promise<string> {
+	try {
+		const payload = (await res.json()) as { message?: string; error?: string };
+		return payload.message || payload.error || `HTTP ${res.status}`;
+	} catch {
+		return `HTTP ${res.status}`;
+	}
+}
+
+export const pause = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,0 +1,52 @@
+import { performScan } from "../api/scan";
+import { auditReportJson } from "../report/json";
+import { type AuditReport, toAuditReport } from "../report/model";
+import { renderAuditReport } from "../report/terminal";
+import { spinner } from "../ui/spinner";
+
+export interface AuditCommandInput {
+	url: string;
+	json: boolean;
+	minScore: number | null;
+	showSkipped: boolean;
+	showPassing: boolean;
+}
+
+// Exit codes: 0 scan ok (and above --min-score when given) · 1 under the
+// threshold · 2 anything went wrong.
+export async function auditCommand(input: AuditCommandInput): Promise<number> {
+	const target = input.url.replace(/\/+$/, "");
+	const interactive = !input.json;
+
+	if (interactive) spinner.start(`Scanning ${target} with ora`);
+
+	let report: AuditReport;
+	try {
+		const scan = await performScan(target, {
+			progress: interactive ? (line) => spinner.update(line) : undefined,
+		});
+		report = toAuditReport(scan, target);
+	} catch (cause) {
+		spinner.stop();
+		console.error(`Audit failed: ${cause instanceof Error ? cause.message : String(cause)}`);
+		return 2;
+	}
+	spinner.stop();
+
+	if (input.json) {
+		process.stdout.write(`${auditReportJson(report)}\n`);
+	} else {
+		for (const line of renderAuditReport(report, {
+			showSkipped: input.showSkipped,
+			showPassing: input.showPassing,
+		})) {
+			console.log(line);
+		}
+	}
+
+	if (input.minScore !== null && report.score < input.minScore) {
+		if (interactive) console.log(`Score ${report.score} is below minimum ${input.minScore}`);
+		return 1;
+	}
+	return 0;
+}

--- a/src/commands/journey.ts
+++ b/src/commands/journey.ts
@@ -1,0 +1,219 @@
+import pc from "picocolors";
+import {
+	type JourneyInsight,
+	type JourneyRun,
+	type JourneyStep,
+	type RunSpend,
+	type RunSummary,
+	launchJourney,
+} from "../api/platform";
+import { flow, squeeze, stdoutWidth } from "../ui/ansi";
+import {
+	buildJourneyTree,
+	drawJourneyTree,
+	isSearchStep,
+	journeySummary,
+	splitUrl,
+} from "../ui/graph";
+import { LivePanel } from "../ui/panel";
+
+export interface JourneyCommandInput {
+	intent: string;
+	domain?: string;
+	harness: string;
+	model?: string;
+	json: boolean;
+}
+
+const wide = () => stdoutWidth(60, 120);
+
+// Present-tense caption for whatever the agent is doing right now.
+function activityLabel(step: JourneyStep): string {
+	if (step.type === "tool_call") {
+		const detail = step.input_display ?? step.summary ?? "";
+		if (isSearchStep(step)) return detail ? `searching ${squeeze(detail, 40)}` : "searching…";
+		const { host } = splitUrl(detail);
+		return host ? `fetching ${host}` : "fetching…";
+	}
+	if (step.type === "text" && step.kind === "reasoning") return "deciding next step…";
+	if (step.type === "text") return "writing the answer…";
+	return "working…";
+}
+
+const chipTokens = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n));
+
+function chipCost(usd: number): string {
+	if (usd < 0.01) return `$${usd.toFixed(4)}`;
+	if (usd < 1) return `$${usd.toFixed(3)}`;
+	return `$${usd.toFixed(2)}`;
+}
+
+function outcomeLines(summary: RunSummary, spend?: RunSpend): string[] {
+	const won = summary.outcome === "success";
+	const chips: string[] = [];
+	if (summary.num_turns != null) chips.push(`${summary.num_turns} turns`);
+	if (summary.duration_ms != null) chips.push(`${(summary.duration_ms / 1000).toFixed(1)}s`);
+	if (spend?.totalTokens != null) chips.push(`${chipTokens(spend.totalTokens)} tokens`);
+	if (spend?.costUsd != null) chips.push(chipCost(spend.costUsd));
+
+	return [
+		"",
+		`  ${pc.dim("─".repeat(Math.min(wide() - 4, 52)))}`,
+		`  ${won ? pc.green("✓") : pc.red("✗")} ${pc.bold(won ? "completed" : summary.outcome)}${
+			chips.length ? `  ${pc.dim(chips.join(" · "))}` : ""
+		}`,
+	];
+}
+
+function gauge(score: number, cells = 22): string {
+	const bound = Math.min(100, Math.max(0, score));
+	const lit = Math.round((bound / 100) * cells);
+	const paint = bound >= 70 ? pc.green : bound >= 50 ? pc.yellow : pc.red;
+	return paint("█".repeat(lit)) + pc.dim("░".repeat(cells - lit));
+}
+
+function priorityDot(priority?: string): string {
+	if (priority === "high") return pc.red("● high  ");
+	if (priority === "medium") return pc.yellow("● medium");
+	if (priority === "low") return pc.dim("● low   ");
+	return pc.dim("●       ");
+}
+
+function insightLines(insight: JourneyInsight): string[] {
+	const rows: string[] = [""];
+
+	if (insight.visibility_score != null) {
+		const score = insight.visibility_score;
+		const paint = score >= 70 ? pc.green : score >= 50 ? pc.yellow : pc.red;
+		const verdict = insight.intent_satisfied
+			? pc.green("✓ intent satisfied")
+			: pc.yellow("✗ intent not satisfied");
+		rows.push(
+			`  ${pc.bold("Visibility")}  ${gauge(score)} ${paint(pc.bold(`${score}/100`))}   ${verdict}`,
+		);
+	}
+	if (insight.summary) {
+		rows.push("");
+		for (const line of flow(insight.summary, wide() - 4)) rows.push(`  ${pc.dim(line)}`);
+	}
+	if (insight.friction_points?.length) {
+		rows.push("", `  ${pc.bold("Friction")}`);
+		for (const point of insight.friction_points) {
+			const [first, ...rest] = flow(point, wide() - 6);
+			rows.push(`    ${pc.yellow("·")} ${first}`);
+			for (const line of rest) rows.push(`      ${line}`);
+		}
+	}
+	if (insight.recommendations?.length) {
+		rows.push("", `  ${pc.bold("Recommendations")}`);
+		for (const rec of insight.recommendations) {
+			rows.push(`    ${priorityDot(rec.priority)}  ${pc.bold(rec.title)}`);
+			for (const line of flow(rec.detail, wide() - 8)) rows.push(`      ${pc.dim(line)}`);
+		}
+	}
+	rows.push("");
+	return rows;
+}
+
+function journeyRunJson(run: JourneyRun): string {
+	const insight = run.insight ?? {};
+	return JSON.stringify(
+		{
+			runId: run.runId,
+			intent: run.intent,
+			domain: run.domain,
+			harness: run.harness,
+			model: run.result?.effective_model ?? run.result?.model,
+			outcome: run.result?.outcome,
+			durationMs: run.result?.duration_ms,
+			numTurns: run.result?.num_turns,
+			totalTokens: run.usage?.totalTokens,
+			inputTokens: run.usage?.inputTokens,
+			outputTokens: run.usage?.outputTokens,
+			costUsd: run.usage?.costUsd,
+			visibilityScore: insight.visibility_score,
+			intentSatisfied: insight.intent_satisfied,
+			taskSatisfied: insight.task_satisfied,
+			summary: insight.summary,
+			keyObservations: insight.key_observations,
+			frictionPoints: insight.friction_points,
+			recommendations: insight.recommendations,
+			journeyLayers: insight.journey_layers,
+			intentCategory: insight.intent_category,
+			steps: run.trajectory,
+		},
+		null,
+		2,
+	);
+}
+
+// Exit codes: 0 run outcome "success" · 1 finished otherwise · 2 error.
+export async function journeyCommand(input: JourneyCommandInput): Promise<number> {
+	const request = {
+		intent: input.intent,
+		domain: input.domain,
+		harness: input.harness,
+		model: input.model,
+	};
+
+	if (input.json) {
+		try {
+			const run = await launchJourney(request);
+			process.stdout.write(`${journeyRunJson(run)}\n`);
+			return run.result?.outcome === "success" ? 0 : 1;
+		} catch (cause) {
+			console.error(`Journey failed: ${cause instanceof Error ? cause.message : String(cause)}`);
+			return 2;
+		}
+	}
+
+	const panel = new LivePanel();
+	let steps: JourneyStep[] = [];
+	let settled = false;
+
+	const view = (): string[] => [
+		`  ${journeySummary(steps)}`,
+		"",
+		...drawJourneyTree(buildJourneyTree(steps, input.intent, settled)).map((row) => `  ${row}`),
+	];
+
+	console.log();
+	console.log(
+		`  ${pc.cyan("▶")} ${input.domain ? pc.bold(input.domain) : pc.dim("(no domain)")}  ${pc.dim("·")}  ${pc.dim(input.harness)}`,
+	);
+	console.log();
+	panel.open();
+	panel.draw(view(), "waking the agent");
+
+	try {
+		const run = await launchJourney(request, {
+			snapshot: (latest) => {
+				steps = latest;
+				const tail = latest[latest.length - 1];
+				panel.draw(view(), tail ? activityLabel(tail) : "working");
+			},
+			finished: () => {
+				settled = true;
+				panel.draw(view(), "scoring the journey");
+			},
+		});
+
+		// Swap the live region for a permanent copy, then the finale under it.
+		panel.close();
+		settled = true;
+		if (run.trajectory.length) steps = run.trajectory;
+		for (const row of view()) console.log(row);
+		if (run.result) for (const row of outcomeLines(run.result, run.usage)) console.log(row);
+		if (run.insight) {
+			for (const row of insightLines(run.insight)) console.log(row);
+		} else if (run.result) {
+			console.log(pc.dim("  (insight not available for this run)"));
+			console.log();
+		}
+		return run.result?.outcome === "success" ? 0 : 1;
+	} catch (cause) {
+		panel.close();
+		console.error(`Journey failed: ${cause instanceof Error ? cause.message : String(cause)}`);
+		return 2;
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,140 @@
+import { defineCommand, runMain } from "citty";
+import pc from "picocolors";
+import pkg from "../package.json";
+import { auditCommand } from "./commands/audit";
+import { journeyCommand } from "./commands/journey";
+
+const NAME = "ax";
+
+const audit = defineCommand({
+	meta: {
+		name: "audit",
+		description: "Score a site's agent readiness",
+	},
+	args: {
+		url: {
+			type: "positional",
+			description: "URL to audit (e.g. https://docs.example.com)",
+			required: true,
+		},
+		json: { type: "boolean", description: "Output as JSON", default: false },
+		"min-score": { type: "string", description: "Exit 1 when the score is under n" },
+		"show-passing": {
+			type: "boolean",
+			description: "List each passing check individually",
+			default: false,
+		},
+		"show-skipped": {
+			type: "boolean",
+			description: "List not-applicable / pending checks too",
+			default: false,
+		},
+	},
+	async run({ args }) {
+		let minScore: number | null = null;
+		if (args["min-score"] !== undefined) {
+			const parsed = Number(args["min-score"]);
+			if (!Number.isFinite(parsed)) {
+				console.error(`Invalid --min-score: ${args["min-score"]}`);
+				process.exit(2);
+			}
+			minScore = parsed;
+		}
+		process.exit(
+			await auditCommand({
+				url: args.url as string,
+				json: Boolean(args.json),
+				minScore,
+				showSkipped: Boolean(args["show-skipped"]),
+				showPassing: Boolean(args["show-passing"]),
+			}),
+		);
+	},
+});
+
+const journey = defineCommand({
+	meta: {
+		name: "journey",
+		description: "Send a real AI agent at a site and watch it navigate live",
+	},
+	args: {
+		intent: {
+			type: "positional",
+			description: 'Goal for the agent (e.g. "Find the API docs and how to auth")',
+			required: true,
+		},
+		domain: { type: "string", description: "Site the agent targets (e.g. stripe.com)" },
+		harness: {
+			type: "string",
+			description: "Agent harness: claude-code, codex, aider, …",
+			default: "claude-code",
+		},
+		model: { type: "string", description: "Model override (harness default when omitted)" },
+		json: { type: "boolean", description: "Output as JSON", default: false },
+	},
+	async run({ args }) {
+		process.exit(
+			await journeyCommand({
+				intent: args.intent as string,
+				domain: args.domain as string | undefined,
+				harness: args.harness as string,
+				model: args.model as string | undefined,
+				json: Boolean(args.json),
+			}),
+		);
+	},
+});
+
+function helpScreen(): string {
+	const g = pc.green("$");
+	const d = pc.dim;
+	return [
+		"",
+		`  ${pc.bold(NAME)} ${d(`v${pkg.version}`)}`,
+		`  ${d("Score any site's agent readiness — and watch real AI agents navigate it")}`,
+		"",
+		`  ${d("Commands:")}`,
+		`    audit ${d("<url>")}       ${d("Score a site's agent readiness")}`,
+		`    journey ${d("<intent>")}  ${d("Send a real agent at a site and watch it live")}`,
+		"",
+		`  ${d("Examples:")}`,
+		`    ${g} ${NAME} audit https://docs.example.com`,
+		`    ${g} ${NAME} audit https://docs.example.com --min-score 70`,
+		`    ${g} ${NAME} journey "Find the API docs and how to authenticate" --domain stripe.com`,
+		`    ${g} ${NAME} journey "Sign up for an account" --domain example.com --harness codex`,
+		"",
+		`  ${d("audit options:")}`,
+		`    --json           ${d("Output as JSON")}`,
+		`    --min-score <n>  ${d("Exit 1 when the score is under n")}`,
+		`    --show-passing   ${d("List each passing check (hidden by default)")}`,
+		`    --show-skipped   ${d("List skipped checks (hidden by default)")}`,
+		"",
+		`  ${d("journey options:")}`,
+		`    --domain <d>     ${d("Site the agent targets (e.g. stripe.com)")}`,
+		`    --harness <h>    ${d("Agent harness: claude-code, codex, aider, … (default claude-code)")}`,
+		`    --model <m>      ${d("Model override (harness default when omitted)")}`,
+		`    --json           ${d("Output as JSON")}`,
+		`    ${d("requires ORA_API_KEY (see .env.example)")}`,
+		"",
+	].join("\n");
+}
+
+const root = defineCommand({
+	meta: {
+		name: NAME,
+		version: pkg.version,
+		description: "Score any site's agent readiness — and watch real AI agents navigate it",
+	},
+	subCommands: { audit, journey },
+	setup() {
+		// Bare invocation and top-level --help get the curated screen; subcommand
+		// --help stays with citty's generated usage.
+		const first = process.argv[2];
+		if (!first || first === "--help" || first === "-h") {
+			console.log(helpScreen());
+			process.exit(0);
+		}
+	},
+});
+
+runMain(root);

--- a/src/report/json.test.ts
+++ b/src/report/json.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { auditReportJson } from "./json";
+import type { AuditReport } from "./model";
+
+const REPORT: AuditReport = {
+	url: "https://acme.dev",
+	score: 75,
+	rating: "Good",
+	summary: "Mostly ready.",
+	sections: [
+		{
+			name: "Agent Access",
+			passed: 2,
+			total: 3,
+			skipped: 1,
+			checks: [
+				{ name: "agent gateway", passed: true, tier: "required", detail: "negotiated" },
+				{ name: "crawler policy", passed: true, tier: "required" },
+				{
+					name: "markdown mirror",
+					passed: false,
+					tier: "recommended",
+					detail: "missing",
+					hint: "Serve .md twins",
+					estScoreGain: 1.8,
+					status: "fail",
+				},
+				{
+					name: "mcp endpoint",
+					passed: false,
+					skipped: true,
+					tier: "optional",
+					detail: "not applicable",
+					status: "na",
+				},
+			],
+		},
+	],
+};
+
+describe("auditReportJson", () => {
+	it("emits the full result with snake_cased category keys", () => {
+		const body = JSON.parse(auditReportJson(REPORT));
+		expect(body.url).toBe("https://acme.dev");
+		expect(body.score).toBe(75);
+		expect(body.rating).toBe("Good");
+		expect(body.summary).toBe("Mostly ready.");
+		expect(Object.keys(body.categories)).toEqual(["agent_access"]);
+		expect(body.categories.agent_access).toMatchObject({ passed: 2, total: 3, skipped: 1 });
+	});
+
+	it("includes every check — passed, failed, and skipped — regardless of view flags", () => {
+		const body = JSON.parse(auditReportJson(REPORT));
+		const checks = body.categories.agent_access.checks;
+		expect(checks).toHaveLength(4);
+		expect(checks[2]).toMatchObject({
+			name: "markdown mirror",
+			passed: false,
+			skipped: false,
+			hint: "Serve .md twins",
+			estScoreGain: 1.8,
+			status: "fail",
+		});
+		expect(checks[3]).toMatchObject({ name: "mcp endpoint", skipped: true });
+		// absent optional fields are dropped, not nulled
+		expect("hint" in checks[0]).toBe(false);
+	});
+
+	it("slugs multi-word and punctuated section names", () => {
+		const twisted: AuditReport = {
+			...REPORT,
+			sections: [{ ...REPORT.sections[0], name: "  Découverte & Reach!  " }],
+		};
+		const body = JSON.parse(auditReportJson(twisted));
+		expect(Object.keys(body.categories)).toEqual(["d_couverte_reach"]);
+	});
+});

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -1,0 +1,43 @@
+import type { AuditReport } from "./model";
+
+// The machine-readable result. Deliberately complete: every check — passing,
+// failing, or skipped — is present no matter which --show-* flags were given,
+// so scripts never depend on display options.
+
+function slugOf(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_|_$/g, "");
+}
+
+export function auditReportJson(report: AuditReport): string {
+	const body = {
+		url: report.url,
+		score: report.score,
+		rating: report.rating,
+		summary: report.summary,
+		categories: Object.fromEntries(
+			report.sections.map((section) => [
+				slugOf(section.name),
+				{
+					passed: section.passed,
+					total: section.total,
+					skipped: section.skipped,
+					checks: section.checks.map((check) => ({
+						name: check.name,
+						status: check.status,
+						passed: check.passed,
+						skipped: check.skipped ?? false,
+						tier: check.tier,
+						estScoreGain: check.estScoreGain,
+						detail: check.detail,
+						hint: check.hint,
+						url: check.url,
+					})),
+				},
+			]),
+		),
+	};
+	return JSON.stringify(body, null, 2);
+}

--- a/src/report/model.test.ts
+++ b/src/report/model.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import type { ScanResult } from "../api/scan";
+import { type AuditCheck, ratingFor, sectionOf, toAuditReport } from "./model";
+
+const SCAN: ScanResult = {
+	domain: "acme.dev",
+	url: "https://acme.dev",
+	score: 82,
+	grade: "B",
+	analysisStatus: "complete",
+	agenticSummary: "acme.dev greets agents well but hides its spec.",
+	pendingChecks: [],
+	layers: [
+		{
+			id: "access",
+			name: "Agent Access",
+			score: 12,
+			maxScore: 24,
+			checks: [
+				{
+					id: "gateway",
+					name: "agent gateway",
+					description: "Serves markdown to agent user-agents",
+					status: "pass",
+					score: 10,
+					maxScore: 10,
+					details: "content negotiated",
+				},
+				{
+					id: "mirror",
+					name: "markdown mirror",
+					description: "A .md twin exists for every page",
+					status: "fail",
+					score: 0,
+					maxScore: 6,
+					details: "0 of 12 pages mirrored",
+					recommendation: "Serve a .md variant of each documentation page",
+					estScoreGain: 1.8,
+				},
+				{
+					id: "mcp",
+					name: "mcp endpoint",
+					description: "Advertises an MCP server",
+					status: "na",
+					score: 0,
+					maxScore: 4,
+					details: "not applicable here",
+				},
+				{
+					id: "crawlers",
+					name: "crawler policy",
+					description: "AI crawlers may fetch content",
+					status: "warning",
+					score: 2,
+					maxScore: 4,
+					details: "two bots blocked",
+				},
+			],
+		},
+	],
+};
+
+const pick = (checks: AuditCheck[], name: string) => checks.find((c) => c.name === name);
+
+describe("toAuditReport", () => {
+	it("turns layers into sections and keeps score + rating", () => {
+		const report = toAuditReport(SCAN, "https://acme.dev");
+		expect(report.url).toBe("https://acme.dev");
+		expect(report.score).toBe(82);
+		expect(report.rating).toBe("Good");
+		expect(report.sections.map((s) => s.name)).toEqual(["Agent Access"]);
+	});
+
+	it("counts pass/fail/skip with na+pending excluded and warning as a failure", () => {
+		const [section] = toAuditReport(SCAN, "x").sections;
+		expect(section.passed).toBe(1);
+		expect(section.total).toBe(3); // mcp endpoint (na) is out of the denominator
+		expect(section.skipped).toBe(1);
+		expect(pick(section.checks, "crawler policy")?.passed).toBe(false);
+		expect(pick(section.checks, "mcp endpoint")).toMatchObject({ passed: false, skipped: true });
+	});
+
+	it("keeps the raw status, estScoreGain, and summary", () => {
+		const report = toAuditReport(SCAN, "x");
+		expect(report.summary).toBe("acme.dev greets agents well but hides its spec.");
+		const checks = report.sections[0].checks;
+		expect(pick(checks, "agent gateway")?.status).toBe("pass");
+		expect(pick(checks, "crawler policy")?.status).toBe("warning");
+		expect(pick(checks, "markdown mirror")?.estScoreGain).toBe(1.8);
+	});
+
+	it("takes the fix from `recommendation`, never from `description`", () => {
+		const checks = toAuditReport(SCAN, "x").sections[0].checks;
+		const mirror = pick(checks, "markdown mirror");
+		expect(mirror?.detail).toBe("0 of 12 pages mirrored");
+		expect(mirror?.hint).toBe("Serve a .md variant of each documentation page");
+		// passing and skipped checks never get a hint
+		expect(pick(checks, "agent gateway")?.hint).toBeUndefined();
+		expect(pick(checks, "mcp endpoint")?.hint).toBeUndefined();
+	});
+
+	it("derives tiers from each check's weight within its layer", () => {
+		const checks = toAuditReport(SCAN, "x").sections[0].checks;
+		expect(pick(checks, "agent gateway")?.tier).toBe("required"); // 10/10
+		expect(pick(checks, "markdown mirror")?.tier).toBe("recommended"); // 6/10
+		expect(pick(checks, "crawler policy")?.tier).toBe("recommended"); // 4/10
+	});
+
+	it("clamps scores into 0-100 and falls back to the requested URL", () => {
+		expect(toAuditReport({ score: 140, layers: [] }, "x").score).toBe(100);
+		expect(toAuditReport({ score: -5, layers: [] }, "x").score).toBe(0);
+		expect(toAuditReport({ score: 50 }, "https://asked.example").url).toBe("https://asked.example");
+		expect(toAuditReport({ score: 50, layers: [] }, "x").sections).toEqual([]);
+	});
+});
+
+describe("ratingFor", () => {
+	it("maps the score bands", () => {
+		expect(ratingFor(100)).toBe("Excellent");
+		expect(ratingFor(90)).toBe("Excellent");
+		expect(ratingFor(89)).toBe("Good");
+		expect(ratingFor(70)).toBe("Good");
+		expect(ratingFor(69)).toBe("Fair");
+		expect(ratingFor(50)).toBe("Fair");
+		expect(ratingFor(49)).toBe("Needs Improvement");
+		expect(ratingFor(0)).toBe("Needs Improvement");
+	});
+});
+
+describe("sectionOf", () => {
+	const entry = (name: string, passed: boolean, skipped = false): AuditCheck => ({
+		name,
+		passed,
+		skipped: skipped || undefined,
+		tier: "recommended",
+	});
+
+	it("excludes skipped checks from the totals but keeps them on the section", () => {
+		const section = sectionOf("S", [entry("a", true), entry("b", false), entry("c", false, true)]);
+		expect(section.passed).toBe(1);
+		expect(section.total).toBe(2);
+		expect(section.skipped).toBe(1);
+		expect(section.checks).toHaveLength(3);
+	});
+
+	it("handles an all-skipped section", () => {
+		const section = sectionOf("S", [entry("a", false, true), entry("b", false, true)]);
+		expect(section.total).toBe(0);
+		expect(section.skipped).toBe(2);
+	});
+});

--- a/src/report/model.ts
+++ b/src/report/model.ts
@@ -1,0 +1,116 @@
+import type { ScanCheck, ScanCheckStatus, ScanResult } from "../api/scan";
+
+// The report model the renderers consume, plus the mapping from ora's raw
+// ScanResult into it. Kept separate from the API client so the wire shape can
+// evolve without touching presentation.
+
+export type CheckTier = "required" | "recommended" | "optional";
+
+export const TIER_RANK: Record<CheckTier, number> = { required: 0, recommended: 1, optional: 2 };
+
+export interface AuditCheck {
+	name: string;
+	passed: boolean;
+	skipped?: boolean;
+	/** The finding — what the scan observed. */
+	detail?: string;
+	/** The fix — what to implement. */
+	hint?: string;
+	url?: string;
+	tier: CheckTier;
+	/** ora's raw verdict for this check, when known. */
+	status?: ScanCheckStatus;
+	/** Estimated points recovered by fixing this check, when known. */
+	estScoreGain?: number;
+}
+
+export interface AuditSection {
+	name: string;
+	checks: AuditCheck[];
+	/** Passing count among non-skipped checks. */
+	passed: number;
+	/** Non-skipped check count. */
+	total: number;
+	skipped: number;
+}
+
+export interface AuditReport {
+	url: string;
+	score: number;
+	rating: string;
+	/** ora's one-line agentic verdict, when it arrived. */
+	summary?: string;
+	sections: AuditSection[];
+}
+
+export function ratingFor(score: number): string {
+	if (score >= 90) return "Excellent";
+	if (score >= 70) return "Good";
+	if (score >= 50) return "Fair";
+	return "Needs Improvement";
+}
+
+export function sectionOf(name: string, checks: AuditCheck[]): AuditSection {
+	const counted = checks.filter((c) => !c.skipped);
+	return {
+		name,
+		checks,
+		passed: counted.filter((c) => c.passed).length,
+		total: counted.length,
+		skipped: checks.length - counted.length,
+	};
+}
+
+/**
+ * ora has no required/recommended/optional notion; approximate one from each
+ * check's weight relative to the heaviest check in its layer, so the report
+ * can keep a "most important first" ordering.
+ */
+function tierOf(weight: number, heaviest: number): CheckTier {
+	if (heaviest <= 0) return "recommended";
+	const share = weight / heaviest;
+	if (share >= 0.75) return "required";
+	if (share >= 0.4) return "recommended";
+	return "optional";
+}
+
+function convertCheck(raw: ScanCheck, heaviest: number): AuditCheck {
+	// pass → passed; na/pending → skipped (kept out of every count);
+	// fail/warning/error all surface as issues (warning just gets a softer glyph).
+	const passed = raw.status === "pass";
+	const skipped = raw.status === "na" || raw.status === "pending";
+
+	const check: AuditCheck = {
+		name: raw.name,
+		passed,
+		tier: tierOf(raw.maxScore ?? 0, heaviest),
+		status: raw.status,
+	};
+	if (skipped) check.skipped = true;
+	if (raw.details) check.detail = raw.details;
+	if (typeof raw.estScoreGain === "number") check.estScoreGain = raw.estScoreGain;
+	// The how-to-fix column must come from `recommendation` (the remedy) and
+	// never `description` (a restatement of what the check inspects).
+	if (!passed && !skipped && raw.recommendation) check.hint = raw.recommendation;
+	return check;
+}
+
+export function toAuditReport(scan: ScanResult, requestedUrl: string): AuditReport {
+	const sections = (scan.layers ?? []).map((layer) => {
+		const heaviest = layer.checks.reduce((top, c) => Math.max(top, c.maxScore ?? 0), 0);
+		return sectionOf(
+			layer.name,
+			layer.checks.map((c) => convertCheck(c, heaviest)),
+		);
+	});
+
+	const score = Math.min(100, Math.max(0, Math.round(scan.score ?? 0)));
+
+	return {
+		url: scan.url ?? requestedUrl,
+		score,
+		rating: ratingFor(score),
+		summary: scan.agenticSummary,
+		sections,
+	};
+}

--- a/src/report/terminal.ts
+++ b/src/report/terminal.ts
@@ -1,0 +1,259 @@
+import pc from "picocolors";
+import { type AuditCheck, type AuditReport, type AuditSection, TIER_RANK } from "./model";
+
+// Layered terminal report: a scored header, one block per layer with a pass
+// bar, and a bordered issues grid sorted by estimated score gain. All wrapping
+// happens on plain text; styling is applied to whole cell lines afterwards so
+// escape codes never enter the width arithmetic.
+
+export interface ReportView {
+	/** Also list not-applicable / pending checks. */
+	showSkipped?: boolean;
+	/** Also list each passing check (the layer bar is the default signal). */
+	showPassing?: boolean;
+}
+
+type Paint = (s: string) => string;
+type CellValue = string | [string, Paint];
+
+const FLOOR_WIDTH = 80;
+const CEIL_WIDTH = 120;
+const BAR_CELLS = 10;
+
+function reportWidth(): number {
+	return Math.min(CEIL_WIDTH, Math.max(FLOOR_WIDTH, process.stdout.columns ?? 100));
+}
+
+function padTo(value: string, span: number): string {
+	return value.length < span ? value + " ".repeat(span - value.length) : value;
+}
+
+// Wrap at word boundaries; a single token wider than the column (long URLs)
+// gets chopped at the column edge rather than blowing up the table.
+function hardWrap(value: string, span: number): string[] {
+	if (span <= 0 || value.length <= span) return [value];
+	const rows: string[] = [];
+	let row = "";
+	for (const token of value.split(/\s+/)) {
+		row = row ? `${row} ${token}` : token;
+		while (row.length > span) {
+			const gap = row.lastIndexOf(" ");
+			if (gap > 0 && row.length - gap - 1 <= span) {
+				rows.push(row.slice(0, gap));
+				row = row.slice(gap + 1);
+			} else {
+				rows.push(row.slice(0, span));
+				row = row.slice(span);
+			}
+		}
+	}
+	if (row) rows.push(row);
+	return rows.length ? rows : [""];
+}
+
+// --- Grid table ---
+
+interface Col {
+	title: string;
+	width: number;
+	paint?: Paint;
+}
+
+function tableLines(cols: Col[], rows: CellValue[][]): string[] {
+	const rule = (left: string, joint: string, right: string) =>
+		pc.dim(left + cols.map((c) => "─".repeat(c.width + 2)).join(joint) + right);
+	const edge = pc.dim("│");
+
+	const paintRow = (cells: CellValue[], override?: Paint): string[] => {
+		const wrapped = cells.map((cell, i) =>
+			hardWrap(typeof cell === "string" ? cell : cell[0], cols[i].width),
+		);
+		const tall = Math.max(1, ...wrapped.map((w) => w.length));
+		const out: string[] = [];
+		for (let line = 0; line < tall; line++) {
+			const segments = wrapped.map((w, i) => {
+				const padded = padTo(w[line] ?? "", cols[i].width);
+				const paint =
+					override ??
+					(typeof cells[i] === "string" ? cols[i].paint : (cells[i] as [string, Paint])[1]);
+				return ` ${paint ? paint(padded) : padded} `;
+			});
+			out.push(edge + segments.join(edge) + edge);
+		}
+		return out;
+	};
+
+	const lines = [rule("┌", "┬", "┐")];
+	lines.push(
+		...paintRow(
+			cols.map((c) => c.title),
+			pc.bold,
+		),
+	);
+	lines.push(rule("├", "┼", "┤"));
+	rows.forEach((row, i) => {
+		lines.push(...paintRow(row));
+		if (i < rows.length - 1) lines.push(rule("├", "┼", "┤"));
+	});
+	lines.push(rule("└", "┴", "┘"));
+	return lines;
+}
+
+// Issues grid: glyph · Check · What's wrong · How to fix. The two prose
+// columns split the remaining room evenly, never dropping under 14 chars; the
+// Check column shrinks (to no less than 12) before prose does.
+function issueCols(term: number, names: string[]): Col[] {
+	const chrome = 4 * 2 + 5; // per-cell padding + vertical rules
+	const room = Math.max(46, term - 4 - chrome); // -4: the block indent
+	const floor = 14;
+	let name = Math.min(26, Math.max("Check".length, ...names.map((n) => n.length)));
+	let free = room - 1 - name;
+	if (free < floor * 2) {
+		name = Math.max(12, name - (floor * 2 - free));
+		free = room - 1 - name;
+	}
+	const wrong = Math.max(floor, Math.ceil(free / 2));
+	const fix = Math.max(floor, free - wrong);
+	return [
+		{ title: "", width: 1 },
+		{ title: "Check", width: name, paint: pc.bold },
+		{ title: "What's wrong", width: wrong },
+		{ title: "How to fix", width: fix, paint: pc.cyan },
+	];
+}
+
+function pairCols(term: number, names: string[], titles: [string, string], paint?: Paint): Col[] {
+	const chrome = 2 * 2 + 3;
+	const room = Math.max(40, term - 4 - chrome);
+	const name = Math.min(30, Math.max(titles[0].length, ...names.map((n) => n.length)));
+	return [
+		{ title: titles[0], width: name, paint },
+		{ title: titles[1], width: Math.max(20, room - name), paint },
+	];
+}
+
+// --- Section pieces ---
+
+function meter(passed: number, total: number): string {
+	if (total <= 0) return pc.dim("─".repeat(BAR_CELLS));
+	const lit = Math.min(BAR_CELLS, Math.max(0, Math.round((passed / total) * BAR_CELLS)));
+	return pc.green("█".repeat(lit)) + pc.dim("░".repeat(BAR_CELLS - lit));
+}
+
+// Biggest estimated gain first; equal gains fall back to tier importance.
+function byImpact(a: AuditCheck, b: AuditCheck): number {
+	const delta = (b.estScoreGain ?? 0) - (a.estScoreGain ?? 0);
+	return delta !== 0 ? delta : TIER_RANK[a.tier] - TIER_RANK[b.tier];
+}
+
+function byTier(a: AuditCheck, b: AuditCheck): number {
+	return TIER_RANK[a.tier] - TIER_RANK[b.tier];
+}
+
+function sectionLines(
+	section: AuditSection,
+	term: number,
+	label: number,
+	view: ReportView,
+): string[] {
+	const lines: string[] = [""];
+
+	const tally =
+		section.total > 0 ? `${section.passed}/${section.total} passed` : "no applicable checks";
+	const skipTail = section.skipped > 0 ? ` · ${section.skipped} skipped` : "";
+	lines.push(
+		`  ${pc.bold(padTo(section.name, label))}  ${meter(section.passed, section.total)} ${pc.dim(tally + skipTail)}`,
+	);
+
+	const issues = section.checks.filter((c) => !c.passed && !c.skipped).sort(byImpact);
+	if (issues.length) {
+		const gain = issues.reduce((sum, c) => sum + (c.estScoreGain ?? 0), 0);
+		const upside = gain >= 0.5 ? ` · +${Math.round(gain)} pts` : "";
+		lines.push(`    ${pc.red("✗")} ${pc.bold(`Issues (${issues.length}${upside})`)}`);
+		const grid = tableLines(
+			issueCols(
+				term,
+				issues.map((c) => c.name),
+			),
+			issues.map((c) => [
+				c.status === "warning" ? ["⚠", pc.yellow] : ["✗", pc.red],
+				c.name,
+				[c.detail ?? "", (s: string) => s],
+				c.hint ?? "",
+			]),
+		);
+		lines.push(...grid.map((row) => `    ${row}`));
+	}
+
+	if (view.showPassing) {
+		const passing = section.checks.filter((c) => c.passed && !c.skipped).sort(byTier);
+		if (passing.length) {
+			lines.push(`    ${pc.green("✓")} ${pc.bold(`Passed (${passing.length})`)}`);
+			const grid = tableLines(
+				pairCols(
+					term,
+					passing.map((c) => c.name),
+					["Check", "Details"],
+				),
+				passing.map((c) => [c.name, c.detail ?? ""]),
+			);
+			lines.push(...grid.map((row) => `    ${row}`));
+		}
+	}
+
+	if (view.showSkipped) {
+		const skipped = section.checks.filter((c) => c.skipped);
+		if (skipped.length) {
+			lines.push(`    ${pc.dim(`○ Skipped (${skipped.length})`)}`);
+			const grid = tableLines(
+				pairCols(
+					term,
+					skipped.map((c) => c.name),
+					["Check", "Reason"],
+					pc.dim,
+				),
+				skipped.map((c) => [c.name, c.detail ?? ""]),
+			);
+			lines.push(...grid.map((row) => `    ${row}`));
+		}
+	}
+
+	return lines;
+}
+
+export function renderAuditReport(report: AuditReport, view: ReportView = {}): string[] {
+	const term = reportWidth();
+	const label = report.sections.reduce((widest, s) => Math.max(widest, s.name.length), 0);
+
+	const lines: string[] = [""];
+	const scorePaint = report.score >= 70 ? pc.green : report.score >= 50 ? pc.yellow : pc.red;
+	lines.push(
+		`  ${pc.bold(report.url)}  ${scorePaint(pc.bold(`${report.score}/100`))} ${pc.dim(report.rating)}`,
+	);
+	if (report.summary) {
+		for (const row of hardWrap(report.summary, term - 4)) lines.push(`  ${pc.dim(row)}`);
+	}
+
+	for (const section of report.sections) {
+		lines.push(...sectionLines(section, term, label, view));
+	}
+
+	// Remind about whatever the default view left out.
+	const passing = report.sections.reduce((n, s) => n + s.passed, 0);
+	const skipped = report.sections.reduce((n, s) => n + s.skipped, 0);
+	const reminders: string[] = [];
+	if (!view.showPassing && passing > 0) {
+		reminders.push(`  Run with --show-passing to list all ${passing} passing checks`);
+	}
+	if (!view.showSkipped && skipped > 0) {
+		reminders.push(
+			`  ${skipped} check${skipped === 1 ? "" : "s"} skipped — run with --show-skipped to see them`,
+		);
+	}
+	if (reminders.length) {
+		lines.push("");
+		for (const reminder of reminders) lines.push(pc.dim(reminder));
+	}
+	lines.push("");
+	return lines;
+}

--- a/src/ui/ansi.ts
+++ b/src/ui/ansi.ts
@@ -1,0 +1,39 @@
+// Small terminal-text helpers shared by the journey renderer. All width math in
+// this package operates on plain strings; color is applied to whole lines only,
+// after wrapping, so ANSI escapes can never skew column calculations.
+
+/** Current stdout width clamped into [lo, hi]; 100 when not a terminal. */
+export function stdoutWidth(lo: number, hi: number): number {
+	const cols = process.stdout.columns ?? 100;
+	return Math.min(hi, Math.max(lo, cols));
+}
+
+/** Collapse runs of whitespace and cap at `max` chars with a trailing ellipsis. */
+export function squeeze(value: string, max: number): string {
+	const flat = value.replace(/\s+/g, " ").trim();
+	return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+/** Greedy word wrap (no hard-breaking); collapses whitespace first. */
+export function flow(value: string, max: number): string[] {
+	const out: string[] = [];
+	let current = "";
+	for (const word of value.replace(/\s+/g, " ").trim().split(" ")) {
+		if (current && current.length + 1 + word.length > max) {
+			out.push(current);
+			current = word;
+		} else {
+			current = current ? `${current} ${word}` : word;
+		}
+	}
+	if (current) out.push(current);
+	return out;
+}
+
+/**
+ * Pulse frames shared by the audit spinner and the journey panel — a breathing
+ * diamond, echoing the ◆ intent marker in the journey graph. Every frame is a
+ * single-cell glyph so `.length` math stays valid; frames are doubled so the
+ * pulse breathes smoothly at the 80ms tick.
+ */
+export const SPINNER_FRAMES = ["◇", "◇", "◈", "◈", "◆", "◆", "◈", "◈"];

--- a/src/ui/graph.test.ts
+++ b/src/ui/graph.test.ts
@@ -1,0 +1,164 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import type { JourneyStep } from "../api/platform";
+import { buildJourneyTree, drawJourneyTree, journeySummary, splitUrl } from "./graph";
+
+const GOAL = "Locate the REST API reference and confirm the auth flow";
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes must go before asserting
+const plain = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+beforeAll(() => {
+	// Freeze a wide virtual terminal so truncation never affects assertions.
+	Object.defineProperty(process.stdout, "columns", { value: 120, configurable: true });
+});
+
+// Shape mirrors a live capture: think → search → fetch that 301s (prior
+// knowledge) → think → fetch discovered on step 3 → fetch discovered on step 5
+// → one thought after the last action. `attribution.referrer.step_id` carries
+// ora's explicit parent edge for the two link-follows.
+const TRAJECTORY: JourneyStep[] = [
+	{
+		id: 0,
+		turn: 1,
+		type: "text",
+		kind: "reasoning",
+		thinking: "Search for the official reference.",
+	},
+	{ id: 1, turn: 2, type: "text", kind: "text", text: "On it." },
+	{
+		id: 2,
+		turn: 3,
+		type: "tool_call",
+		tool: "WebSearch",
+		action: "search",
+		input_display: "acme REST API reference",
+		duration_ms: 3100,
+		attribution: { kind: "web_search", method: "heuristic" },
+		output_structured: { links: [{ url: "https://docs.acme.dev/reference" }] },
+	},
+	{
+		id: 3,
+		turn: 4,
+		type: "tool_call",
+		tool: "WebFetch",
+		action: "fetch",
+		input_display: "GET https://acme.dev/api",
+		status: 301,
+		duration_ms: 240,
+		attribution: { kind: "prior_knowledge", method: "heuristic" },
+	},
+	{ id: 4, turn: 5, type: "text", kind: "reasoning", thinking: "Moved — chase the redirect." },
+	{
+		id: 5,
+		turn: 6,
+		type: "tool_call",
+		tool: "WebFetch",
+		action: "fetch",
+		input_display: "GET https://docs.acme.dev/reference",
+		duration_ms: 410,
+		attribution: { kind: "previous_artifact", referrer: { step_id: 3, turn: 4 } },
+	},
+	{
+		id: 7,
+		turn: 8,
+		type: "tool_call",
+		tool: "WebFetch",
+		action: "fetch",
+		input_display: "GET https://docs.acme.dev/reference/auth",
+		duration_ms: 180,
+		attribution: { kind: "previous_artifact", referrer: { step_id: 5, turn: 6 } },
+	},
+	{ id: 8, turn: 9, type: "text", kind: "reasoning", thinking: "Both pages confirmed." },
+];
+
+describe("splitUrl", () => {
+	it("separates host and path from display text", () => {
+		expect(splitUrl("GET https://docs.acme.dev/reference/auth")).toEqual({
+			host: "docs.acme.dev",
+			path: "/reference/auth",
+		});
+	});
+
+	it("defaults the path and tolerates non-URLs", () => {
+		expect(splitUrl("https://acme.dev")).toEqual({ host: "acme.dev", path: "/" });
+		expect(splitUrl("just words")).toEqual({});
+		expect(splitUrl(undefined)).toEqual({});
+	});
+});
+
+describe("buildJourneyTree", () => {
+	it("roots everything at the intent — no synthetic homepage box", () => {
+		const { root } = buildJourneyTree(TRAJECTORY, GOAL, true);
+		expect(root.kind).toBe("intent");
+		expect(root.icon).toBe("◆");
+		expect(root.label).toBe(GOAL);
+		expect(root.children.map((c) => c.kind)).toEqual(["search", "fetch"]);
+	});
+
+	it("nests link-follows under their referrer step", () => {
+		const { root } = buildJourneyTree(TRAJECTORY, GOAL, true);
+		const entry = root.children[1]; // acme.dev/api — the 301
+		expect(entry.label).toContain("acme.dev/api");
+		expect(entry.tone).toBe("redirect");
+		expect(entry.meta).toBe("↳ 301");
+		expect(entry.children).toHaveLength(1);
+		expect(entry.children[0].label).toContain("docs.acme.dev/reference");
+		expect(entry.children[0].children[0].label).toContain("/reference/auth");
+	});
+
+	it("pins reasoning to the following action and keeps the tail loose", () => {
+		const { root, looseNotes } = buildJourneyTree(TRAJECTORY, GOAL, true);
+		expect(root.children[0].notes).toEqual(["Search for the official reference."]);
+		expect(root.children[1].children[0].notes).toEqual(["Moved — chase the redirect."]);
+		expect(looseNotes).toEqual(["Both pages confirmed."]);
+	});
+
+	it("highlights the newest box only while the agent is still working", () => {
+		const live = buildJourneyTree(TRAJECTORY, GOAL, false);
+		const tip = live.root.children[1].children[0].children[0];
+		expect(tip.tone).toBe("active");
+		expect(tip.meta).toBe("…");
+
+		const done = buildJourneyTree(TRAJECTORY, GOAL, true);
+		expect(done.root.children[1].children[0].children[0].tone).toBe("ok");
+	});
+});
+
+describe("journeySummary", () => {
+	it("tallies steps, reasoning, and searches", () => {
+		const text = plain(journeySummary(TRAJECTORY));
+		expect(text).toContain("8 steps");
+		expect(text).toContain("3 reasoning");
+		expect(text).toContain("1 search");
+	});
+});
+
+describe("drawJourneyTree", () => {
+	it("draws boxes, trunks, elbows, and reasoning markers", () => {
+		const picture = plain(drawJourneyTree(buildJourneyTree(TRAJECTORY, GOAL, true)).join("\n"));
+
+		expect(picture).toContain(`◆ ${GOAL}`);
+		expect(picture).toContain('🔍 "acme REST API reference"');
+		expect(picture).toContain("↳ 301");
+		expect(picture).toContain("docs.acme.dev/reference/auth");
+		// trunk out of a parent, elbows into children
+		expect(picture).toContain("╰─┬");
+		expect(picture).toContain("├──┤");
+		expect(picture).toContain("╰──┤");
+		// reasoning markers ride the edge above their action; the tail floats below
+		expect(picture).toContain("│  (…) Search for the official reference.");
+		expect(picture).toContain("(…) Moved — chase the redirect.");
+		expect(picture).toContain("(…) Both pages confirmed.");
+	});
+
+	it("keeps every box's three border lines column-aligned", () => {
+		const rows = drawJourneyTree(buildJourneyTree(TRAJECTORY, GOAL, true)).map(plain);
+		for (let i = 0; i < rows.length; i++) {
+			const opensAt = rows[i].indexOf("╭");
+			if (opensAt === -1) continue;
+			const bottom = rows[i + 2];
+			expect(bottom.indexOf("╰")).toBe(opensAt);
+			expect(bottom.indexOf("╯")).toBe(rows[i].indexOf("╮"));
+		}
+	});
+});

--- a/src/ui/graph.ts
+++ b/src/ui/graph.ts
@@ -1,0 +1,240 @@
+import pc from "picocolors";
+import type { JourneyStep } from "../api/platform";
+import { squeeze, stdoutWidth } from "./ansi";
+
+// Builds and draws the journey graph — the same picture the ora product shows:
+// the intent at the root, every tool action as a rounded box beneath it, and
+// edges taken from ora's own per-step attribution rather than guessed. The
+// agent's reasoning shows up in the graph itself as (…) markers on the edge
+// above the action it produced.
+//
+// Two deliberate choices, learned from user feedback on the product:
+//   · No synthetic "homepage" node — it would claim a fetch that never
+//     happened. A real homepage fetch appears as an ordinary fetch box.
+//   · Reasoning is placed, not just counted.
+
+export type NodeTone = "root" | "ok" | "redirect" | "error" | "active";
+
+export interface GraphNode {
+	id: number;
+	kind: "intent" | "search" | "fetch";
+	icon: string;
+	label: string;
+	meta?: string;
+	tone: NodeTone;
+	/** One-line reasoning notes attached above this box. */
+	notes: string[];
+	children: GraphNode[];
+}
+
+export interface JourneyTree {
+	root: GraphNode;
+	/** Reasoning with no action after it yet — drawn under the graph. */
+	looseNotes: string[];
+}
+
+/** Pull host + path out of free-form text like `GET https://x.dev/docs`. */
+export function splitUrl(text?: string): { host?: string; path?: string } {
+	if (!text) return {};
+	const hit = text.match(/https?:\/\/([^/\s]+)(\/\S*)?/i);
+	return hit ? { host: hit[1], path: hit[2] ?? "/" } : {};
+}
+
+export function isSearchStep(step: JourneyStep): boolean {
+	return /search/i.test(`${step.tool ?? ""} ${step.action ?? ""}`);
+}
+
+// ⚠ Icon set is fixed on purpose: 🔍 🌐 📄 have .length === 2 AND occupy two
+// columns, while ◆ is 1/1 — so plain .length still equals display width and
+// the box borders line up. Vet any new icon against both properties.
+function iconFor(step: JourneyStep): string {
+	if (isSearchStep(step)) return "🔍";
+	const hint = `${step.tool ?? ""} ${step.action ?? ""}`.toLowerCase();
+	if (/fetch|http|get/.test(hint)) return "🌐";
+	if (/read|open|view/.test(hint)) return "📄";
+	return "🌐";
+}
+
+function nodeFor(step: JourneyStep, labelCap: number): GraphNode {
+	if (isSearchStep(step)) {
+		const query = step.input_display ?? String(step.input?.query ?? "search");
+		const hits = step.output_structured?.links?.length;
+		return {
+			id: step.id,
+			kind: "search",
+			icon: "🔍",
+			label: squeeze(`"${query}"`, labelCap),
+			meta: hits ? `${hits} results` : undefined,
+			tone: "ok",
+			notes: [],
+			children: [],
+		};
+	}
+
+	const { host, path } = splitUrl(step.input_display ?? String(step.input?.url ?? ""));
+	const code = step.status;
+	const bounced = code != null && code >= 300 && code < 400;
+	const failed = Boolean(step.is_error) || (code != null && code >= 400);
+
+	let meta: string;
+	if (bounced) meta = `↳ ${code}`;
+	else if (failed) meta = `✗ ${code ?? "error"}`;
+	else {
+		const chips = ["✓"];
+		if (code) chips.push(String(code));
+		if (step.duration_ms) chips.push(`${(step.duration_ms / 1000).toFixed(1)}s`);
+		meta = chips.join(" ");
+	}
+
+	return {
+		id: step.id,
+		kind: "fetch",
+		icon: iconFor(step),
+		label: squeeze(`${host ?? "?"}${path ?? ""}`, labelCap),
+		meta,
+		tone: bounced ? "redirect" : failed ? "error" : "ok",
+		notes: [],
+		children: [],
+	};
+}
+
+/**
+ * One pass over the trajectory. Reasoning queues up and attaches to the next
+ * action's box. Parents are picked strongest-signal-first:
+ *   1. attribution.referrer.step_id — ora's explicit "found on step N" edge
+ *   2. attribution.kind "web_search"        → newest search box
+ *   3. attribution.kind "previous_artifact" → previous fetch box
+ *   4. anything else (prior knowledge, direct) → the intent root
+ * Searches always hang off the root.
+ */
+export function buildJourneyTree(
+	steps: JourneyStep[],
+	intent: string,
+	settled: boolean,
+): JourneyTree {
+	const wide = stdoutWidth(60, 120);
+	const labelCap = Math.min(52, Math.max(24, wide - 40));
+	const noteCap = Math.max(30, wide - 24);
+
+	const root: GraphNode = {
+		id: -1,
+		kind: "intent",
+		icon: "◆",
+		label: squeeze(intent, noteCap),
+		tone: "root",
+		notes: [],
+		children: [],
+	};
+
+	const nodesByStep = new Map<number, GraphNode>();
+	let queuedNotes: string[] = [];
+	let recentSearch: GraphNode | undefined;
+	let recentFetch: GraphNode | undefined;
+	let newest: GraphNode | undefined;
+
+	for (const step of steps) {
+		if (step.type === "text" && step.kind === "reasoning") {
+			const note = (step.thinking ?? step.text ?? "").trim();
+			if (note) queuedNotes.push(squeeze(note, noteCap));
+			continue;
+		}
+		if (step.type !== "tool_call") continue;
+
+		const node = nodeFor(step, labelCap);
+		node.notes = queuedNotes;
+		queuedNotes = [];
+		nodesByStep.set(step.id, node);
+
+		let parent = root;
+		if (!isSearchStep(step)) {
+			const refStep = step.attribution?.referrer?.step_id;
+			const via = step.attribution?.kind;
+			const referred = refStep != null ? nodesByStep.get(refStep) : undefined;
+			if (referred && referred !== node) parent = referred;
+			else if (via === "web_search" && recentSearch) parent = recentSearch;
+			else if (via === "previous_artifact" && recentFetch) parent = recentFetch;
+		}
+		parent.children.push(node);
+
+		if (isSearchStep(step)) recentSearch = node;
+		else recentFetch = node;
+		newest = node;
+	}
+
+	if (newest && !settled) {
+		newest.tone = "active";
+		newest.meta = "…";
+	}
+	return { root, looseNotes: queuedNotes };
+}
+
+/** "9 steps · 3 reasoning · 1 search" — zero parts omitted (except the total). */
+export function journeySummary(steps: JourneyStep[]): string {
+	const thinking = steps.filter((s) => s.kind === "reasoning").length;
+	const searching = steps.filter((s) => s.type === "tool_call" && isSearchStep(s)).length;
+	const parts = [`${pc.bold(String(steps.length))} steps`];
+	if (thinking) parts.push(`${pc.bold(String(thinking))} reasoning`);
+	if (searching) parts.push(`${pc.bold(String(searching))} search${searching === 1 ? "" : "es"}`);
+	return parts.join(pc.dim("  ·  "));
+}
+
+// --- Drawing ---
+// Each box is three lines. A parent with children opens a trunk (`╰─┬`) from
+// its bottom border; every child gets an elbow (`├──` / `╰──`) that merges
+// into its own left border (`┤`). Prefixes are exactly five columns, so each
+// depth level indents by five and the trunk stays under the parent's ┬.
+
+function tonePalette(tone: NodeTone): { frame: Paint; ink: Paint } {
+	switch (tone) {
+		case "root":
+			return { frame: pc.dim, ink: (s) => pc.bold(s) };
+		case "active":
+			return { frame: pc.cyan, ink: (s) => pc.cyan(pc.bold(s)) };
+		case "redirect":
+			return { frame: pc.yellow, ink: pc.yellow };
+		case "error":
+			return { frame: pc.red, ink: pc.red };
+		default:
+			return { frame: pc.green, ink: pc.green };
+	}
+}
+
+type Paint = (s: string) => string;
+
+const noteLine = (note: string) => pc.dim(`(…) ${note}`);
+
+function drawNode(node: GraphNode, joined: boolean): string[] {
+	const { frame, ink } = tonePalette(node.tone);
+	const bare = `${node.icon} ${node.label}${node.meta ? ` ${node.meta}` : ""}`;
+	const span = bare.length + 2; // one space of padding each side
+	const dressed = `${node.icon} ${ink(node.label)}${node.meta ? ` ${pc.dim(node.meta)}` : ""}`;
+	const branching = node.children.length > 0;
+
+	const out = node.notes.map(noteLine);
+	out.push(frame(`╭${"─".repeat(span)}╮`));
+	out.push(`${frame(joined ? "┤" : "│")} ${dressed} ${frame("│")}`);
+	out.push(frame(branching ? `╰─┬${"─".repeat(span - 2)}╯` : `╰${"─".repeat(span)}╯`));
+
+	node.children.forEach((child, idx) => {
+		const closing = idx === node.children.length - 1;
+		const block = drawNode(child, true);
+		const doorway = child.notes.length + 1; // the child's mid (border) line
+		block.forEach((row, at) => {
+			let lead: string;
+			if (at === doorway) lead = closing ? "  ╰──" : "  ├──";
+			else if (at < doorway) lead = "  │  ";
+			else lead = closing ? "     " : "  │  ";
+			out.push(pc.dim(lead) + row);
+		});
+	});
+	return out;
+}
+
+export function drawJourneyTree(tree: JourneyTree): string[] {
+	const rows = drawNode(tree.root, false);
+	if (tree.looseNotes.length) {
+		rows.push("");
+		rows.push(...tree.looseNotes.map(noteLine));
+	}
+	return rows;
+}

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -1,0 +1,67 @@
+import pc from "picocolors";
+import { SPINNER_FRAMES } from "./ansi";
+
+// A live region that owns the bottom of the screen while a journey runs. The
+// whole graph is repainted in place on every trajectory snapshot (that full
+// redraw is what makes it feel alive); between snapshots — gaps of 5–8s —
+// only the top status line pulses. Painting is per-line erase-and-rewrite
+// (\x1b[2K), never a screen clear, which keeps the redraw flicker-free.
+// On a non-TTY every method is a no-op; the caller prints the final graph once.
+
+export class LivePanel {
+	private rows = 0;
+	private beat = 0;
+	private readonly bornAt = Date.now();
+	private ticker: ReturnType<typeof setInterval> | undefined;
+	private readonly live = Boolean(process.stdout.isTTY);
+	private content: string[] = [];
+	private headline = "";
+
+	open(): void {
+		if (this.live && !this.ticker) this.ticker = setInterval(() => this.pulse(), 100);
+	}
+
+	draw(content: string[], headline: string): void {
+		this.content = content;
+		this.headline = headline;
+		this.repaint();
+	}
+
+	/** Stop and erase the region so a permanent copy can be printed below. */
+	close(): void {
+		if (this.ticker) {
+			clearInterval(this.ticker);
+			this.ticker = undefined;
+		}
+		if (this.live && this.rows > 0) {
+			process.stdout.write(`\x1b[${this.rows}A\r\x1b[0J`);
+			this.rows = 0;
+		}
+	}
+
+	private banner(): string {
+		const glyph = pc.cyan(SPINNER_FRAMES[this.beat % SPINNER_FRAMES.length]);
+		const elapsed = Math.floor((Date.now() - this.bornAt) / 1000);
+		const full = `${this.headline}  ${elapsed}s`;
+		const cap = Math.max(10, (process.stdout.columns ?? 80) - 6);
+		const text = full.length > cap ? `${full.slice(0, cap - 1)}…` : full;
+		return `  ${glyph} ${pc.bold(text)}`;
+	}
+
+	private repaint(): void {
+		if (!this.live) return;
+		const frame = [this.banner(), "", ...this.content];
+		let out = this.rows > 0 ? `\x1b[${this.rows}A` : "";
+		for (const row of frame) out += `\x1b[2K${row}\n`;
+		if (frame.length < this.rows) out += "\x1b[0J"; // wipe leftovers of a taller frame
+		this.rows = frame.length;
+		process.stdout.write(out);
+	}
+
+	// 100ms heartbeat: rewrite just the banner, hop back down, touch nothing else.
+	private pulse(): void {
+		if (!this.live || this.rows === 0) return;
+		this.beat++;
+		process.stdout.write(`\x1b[${this.rows}A\r\x1b[2K${this.banner()}\x1b[${this.rows}B\r`);
+	}
+}

--- a/src/ui/spinner.ts
+++ b/src/ui/spinner.ts
@@ -1,0 +1,44 @@
+import pc from "picocolors";
+import { SPINNER_FRAMES } from "./ansi";
+
+// Single-line progress indicator on stderr, used while an audit scan streams.
+// It only animates when stderr is an interactive terminal; in pipes and CI the
+// carriage-return repaint would otherwise show up as one line per tick.
+
+const TICK_MS = 80;
+
+let handle: ReturnType<typeof setInterval> | undefined;
+let tick = 0;
+let label = "";
+
+function paint(): void {
+	const glyph = pc.cyan(SPINNER_FRAMES[tick % SPINNER_FRAMES.length]);
+	// Cap the label at the terminal width so the line can never soft-wrap and
+	// defeat the \r redraw; \x1b[K erases leftovers from a longer prior label.
+	const cap = Math.max(10, (process.stderr.columns ?? 80) - 2);
+	const shown = label.length > cap ? `${label.slice(0, cap - 1)}…` : label;
+	process.stderr.write(`\r\x1b[K${glyph} ${pc.dim(shown)}`);
+	tick++;
+}
+
+export const spinner = {
+	start(message: string): void {
+		spinner.stop();
+		tick = 0;
+		label = message;
+		if (!process.stderr.isTTY) return;
+		handle = setInterval(paint, TICK_MS);
+	},
+
+	/** Swap the message; the running timer picks it up on the next tick. */
+	update(message: string): void {
+		label = message;
+	},
+
+	stop(): void {
+		if (!handle) return;
+		clearInterval(handle);
+		handle = undefined;
+		process.stderr.write("\r\x1b[K");
+	},
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["ES2022"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"types": ["node"]
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup";
+
+// One self-contained CJS executable: citty and picocolors are bundled in
+// (noExternal), so `npx @ora-ai/ax` has zero install friction.
+export default defineConfig({
+	entry: { main: "src/main.ts" },
+	format: ["cjs"],
+	dts: false,
+	splitting: false,
+	sourcemap: false,
+	banner: { js: "#!/usr/bin/env node" },
+	noExternal: [/.*/],
+	platform: "node",
+	esbuildOptions(options) {
+		options.minify = true;
+	},
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "json"],
+			exclude: ["src/main.ts", "node_modules/", "dist/"],
+		},
+	},
+});


### PR DESCRIPTION
## Summary

Standalone npm package for the ora CLI: `@ora-ai/ax`, bin **`ax`**, a single self-contained CJS binary (citty + picocolors bundled via tsup) so `npx @ora-ai/ax` runs with zero install friction. Node ≥ 20, TypeScript ESM source, biome + vitest.

### `ax scan <url>`
- Streams ora's public scan (`GET /api/scan/stream`, data-only SSE) with a live spinner: URL-kind detection → discovery phases → determinate per-check progress bar.
- Merges the `agenticSummary` that arrives *after* `scan_complete` (`summary_ready`), polls `GET /api/score/{domain}` while analysis is partial, and uses an idle timeout (re-armed per event) instead of a fixed deadline.
- Renders a layered report: score header, per-layer pass bars, and a bordered issues grid ordered by estimated score gain with the actionable fix per row — or the canonical `--json` (every check, regardless of `--show-*` flags).
- Flags: `--json`, `--min-score n` (CI gate → exit 1), `--show-passing`, `--show-skipped`. No API key required.

### `ax journey "<intent>"`
- Auths with `ORA_API_KEY` (header-based token exchange), triggers a run on the ora platform, and follows the named-SSE run stream.
- Live boxed node-graph driven by `trajectory` snapshots: the intent at the root, searches/fetches as boxes, edges from ora's per-step `attribution.referrer`, reasoning as `(…)` markers on the edge that led to each action; full in-place repaint per snapshot with a ticking status line.
- Finale: outcome line with turns/duration/token/cost chips (spend fetched from the runs list with one delayed retry), then the scored visibility insight (gauge, friction points, prioritized recommendations). `--domain`, `--harness`, `--model`, `--json`.

Exit codes across both commands: `0` success · `1` below `--min-score` / non-success outcome · `2` any error.

Also included: `.env.example`, a local mock scan server (`scripts/mock-scan-server.mjs`) for offline UI iteration, and MIT license. `pnpm@10.34.5` is pinned via `packageManager` (pnpm 11 requires Node ≥ 22.13).

## Test plan

- [x] `pnpm typecheck`, `pnpm lint` clean; `pnpm vitest run` — 42/42 (scan client incl. summary merge/partial-poll/429/timeout, platform client incl. auth/trigger/stream/spend/onOpen-once, mapper tiers+clamping, JSON schema, graph build/render incl. border-alignment property test)
- [x] `pnpm build` → `dist/main.cjs`; help screen, subcommand help
- [x] Live scans against ora.ai (vercel.com, example.com) — report + `--json` verified
- [x] Mock-server E2E: default view, `--show-*`, `--json` schema, exit codes 0/1/2
- [x] `pnpm pack` tarball contains only dist + docs (~40 KB)
- [ ] One live `journey` run with a real `ORA_API_KEY` before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)