### PR TITLE
Rename audit to scan; drop --min-score for now

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ora platform API (agentic journeys / runs). Copy to `.env` and fill in.
-# The audit scan uses the public ora.ai host and needs none of these —
-# `ora audit <url>` works with zero configuration.
+# The scan command uses the public ora.ai host and needs none of these —
+# `ax scan <url>` works with zero configuration.
 
 # Secret API key (looks like ora_sk_...). Exchanged for a short-lived bearer token.
 ORA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 Score any site's agent readiness — and watch real AI agents navigate it. Powered by [ora](https://ora.ai)'s hosted APIs.
 
 ```
-npx @ora-ai/ax audit https://stripe.com
+npx @ora-ai/ax scan https://stripe.com
 ```
 
 Two commands:
 
-- **`audit <url>`** — run ora's hosted agent-readiness scan against a site: live progress, then a layered report of what passed, what's broken, and exactly how to fix it (or `--json`). No account or API key needed.
+- **`scan <url>`** — run ora's hosted agent-readiness scan against a site: live progress, then a layered report of what passed, what's broken, and exactly how to fix it (or `--json`). No account or API key needed.
 - **`journey "<intent>"`** — send a real AI agent (claude-code, codex, …) at a site and watch its navigation live as a boxed node-graph, then get the scored insight, tokens, and cost. Requires an `ORA_API_KEY`.
 
-## audit
+## scan
 
 ```
-ax audit <url> [--json] [--min-score n] [--show-passing] [--show-skipped]
+ax scan <url> [--json] [--min-score n] [--show-passing] [--show-skipped]
 ```
 
 ```
@@ -113,7 +113,7 @@ All configuration is environment-first: the consumer defines the variables, the 
 
 | Var | Used by | Default | Purpose |
 |---|---|---|---|
-| `ORA_API_URL` | audit | `https://ora.ai` | Public scan API base (no auth) |
+| `ORA_API_URL` | scan | `https://ora.ai` | Public scan API base (no auth) |
 | `ORA_PLATFORM_URL` | journey | `https://api.staging.agentfront.sh` | Authenticated platform API base |
 | `ORA_API_KEY` | journey | — (required) | Secret key (`ora_sk_…`), exchanged for a short-lived bearer token |
 
@@ -121,8 +121,8 @@ All configuration is environment-first: the consumer defines the variables, the 
 
 | Code | Meaning |
 |---|---|
-| `0` | audit: scan ok (and ≥ `--min-score` if set) · journey: run outcome `success` |
-| `1` | audit: score below `--min-score` · journey: run finished with a non-success outcome |
+| `0` | scan: ok (and ≥ `--min-score` if set) · journey: run outcome `success` |
+| `1` | scan: score below `--min-score` · journey: run finished with a non-success outcome |
 | `2` | any error (bad flag value, API failure, timeout) |
 
 ## Development
@@ -134,17 +134,17 @@ pnpm test:ci         # single run + coverage
 pnpm typecheck
 pnpm lint
 pnpm build           # tsup → dist/main.cjs (single self-contained binary)
-node dist/main.cjs audit https://example.com
+node dist/main.cjs scan https://example.com
 ```
 
 Manual testing without burning the live scan rate limit:
 
 ```sh
 node scripts/mock-scan-server.mjs &
-ORA_API_URL=http://localhost:8799 node dist/main.cjs audit https://stripe.com
+ORA_API_URL=http://localhost:8799 node dist/main.cjs scan https://stripe.com
 ```
 
-To exercise the published-package experience locally: `npm pack`, then `npx ./ora-ai-ax-0.1.0.tgz audit https://example.com`, or `pnpm link --global` and use `ax` directly.
+To exercise the published-package experience locally: `npm pack`, then `npx ./ora-ai-ax-0.1.0.tgz scan https://example.com`, or `pnpm link --global` and use `ax` directly.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Two commands:
 ## scan
 
 ```
-ax scan <url> [--json] [--min-score n] [--show-passing] [--show-skipped]
+ax scan <url> [--json] [--show-passing] [--show-skipped]
 ```
 
 ```
@@ -38,7 +38,6 @@ ax scan <url> [--json] [--min-score n] [--show-passing] [--show-skipped]
 | Flag | Effect |
 |---|---|
 | `--json` | Full machine-readable result on stdout (every check, all layers), nothing else |
-| `--min-score <n>` | Exit `1` if the score is below `n` (for CI gates) |
 | `--show-passing` | List every passing check, not just the per-layer summary bar |
 | `--show-skipped` | Include not-applicable/pending checks with their reason |
 
@@ -121,9 +120,9 @@ All configuration is environment-first: the consumer defines the variables, the 
 
 | Code | Meaning |
 |---|---|
-| `0` | scan: ok (and ≥ `--min-score` if set) · journey: run outcome `success` |
-| `1` | scan: score below `--min-score` · journey: run finished with a non-success outcome |
-| `2` | any error (bad flag value, API failure, timeout) |
+| `0` | scan: completed · journey: run outcome `success` |
+| `1` | journey: run finished with a non-success outcome |
+| `2` | any error (API failure, timeout) |
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
 		"llms.txt",
 		"ora",
 		"cli",
-		"audit"
+		"scan"
 	]
 }

--- a/scripts/mock-scan-server.mjs
+++ b/scripts/mock-scan-server.mjs
@@ -3,7 +3,7 @@
 // burning the live rate limit (10 scans/min/IP):
 //
 //   node scripts/mock-scan-server.mjs [port]         # default 8799
-//   ORA_API_URL=http://localhost:8799 node dist/main.cjs audit https://stripe.com
+//   ORA_API_URL=http://localhost:8799 node dist/main.cjs scan https://stripe.com
 //
 // Serves:
 //   GET /api/scan/stream?domain=X  data-only SSE: progress events, scan_complete
@@ -157,6 +157,6 @@ const server = createServer(async (req, res) => {
 server.listen(PORT, () => {
 	console.log(`mock ora scan API on http://localhost:${PORT}`);
 	console.log(
-		`try: ORA_API_URL=http://localhost:${PORT} node dist/main.cjs audit https://stripe.com`,
+		`try: ORA_API_URL=http://localhost:${PORT} node dist/main.cjs scan https://stripe.com`,
 	);
 });

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,10 +1,10 @@
 import { performScan } from "../api/scan";
-import { auditReportJson } from "../report/json";
-import { type AuditReport, toAuditReport } from "../report/model";
-import { renderAuditReport } from "../report/terminal";
+import { reportJson } from "../report/json";
+import { type Report, toReport } from "../report/model";
+import { renderReport } from "../report/terminal";
 import { spinner } from "../ui/spinner";
 
-export interface AuditCommandInput {
+export interface ScanCommandInput {
 	url: string;
 	json: boolean;
 	minScore: number | null;
@@ -14,29 +14,29 @@ export interface AuditCommandInput {
 
 // Exit codes: 0 scan ok (and above --min-score when given) · 1 under the
 // threshold · 2 anything went wrong.
-export async function auditCommand(input: AuditCommandInput): Promise<number> {
+export async function scanCommand(input: ScanCommandInput): Promise<number> {
 	const target = input.url.replace(/\/+$/, "");
 	const interactive = !input.json;
 
 	if (interactive) spinner.start(`Scanning ${target} with ora`);
 
-	let report: AuditReport;
+	let report: Report;
 	try {
 		const scan = await performScan(target, {
 			progress: interactive ? (line) => spinner.update(line) : undefined,
 		});
-		report = toAuditReport(scan, target);
+		report = toReport(scan, target);
 	} catch (cause) {
 		spinner.stop();
-		console.error(`Audit failed: ${cause instanceof Error ? cause.message : String(cause)}`);
+		console.error(`Scan failed: ${cause instanceof Error ? cause.message : String(cause)}`);
 		return 2;
 	}
 	spinner.stop();
 
 	if (input.json) {
-		process.stdout.write(`${auditReportJson(report)}\n`);
+		process.stdout.write(`${reportJson(report)}\n`);
 	} else {
-		for (const line of renderAuditReport(report, {
+		for (const line of renderReport(report, {
 			showSkipped: input.showSkipped,
 			showPassing: input.showPassing,
 		})) {

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -7,13 +7,11 @@ import { spinner } from "../ui/spinner";
 export interface ScanCommandInput {
 	url: string;
 	json: boolean;
-	minScore: number | null;
 	showSkipped: boolean;
 	showPassing: boolean;
 }
 
-// Exit codes: 0 scan ok (and above --min-score when given) · 1 under the
-// threshold · 2 anything went wrong.
+// Exit codes: 0 scan ok · 2 anything went wrong.
 export async function scanCommand(input: ScanCommandInput): Promise<number> {
 	const target = input.url.replace(/\/+$/, "");
 	const interactive = !input.json;
@@ -44,9 +42,5 @@ export async function scanCommand(input: ScanCommandInput): Promise<number> {
 		}
 	}
 
-	if (input.minScore !== null && report.score < input.minScore) {
-		if (interactive) console.log(`Score ${report.score} is below minimum ${input.minScore}`);
-		return 1;
-	}
 	return 0;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,20 @@
 import { defineCommand, runMain } from "citty";
 import pc from "picocolors";
 import pkg from "../package.json";
-import { auditCommand } from "./commands/audit";
 import { journeyCommand } from "./commands/journey";
+import { scanCommand } from "./commands/scan";
 
 const NAME = "ax";
 
-const audit = defineCommand({
+const scan = defineCommand({
 	meta: {
-		name: "audit",
+		name: "scan",
 		description: "Score a site's agent readiness",
 	},
 	args: {
 		url: {
 			type: "positional",
-			description: "URL to audit (e.g. https://docs.example.com)",
+			description: "URL to scan (e.g. https://docs.example.com)",
 			required: true,
 		},
 		json: { type: "boolean", description: "Output as JSON", default: false },
@@ -41,7 +41,7 @@ const audit = defineCommand({
 			minScore = parsed;
 		}
 		process.exit(
-			await auditCommand({
+			await scanCommand({
 				url: args.url as string,
 				json: Boolean(args.json),
 				minScore,
@@ -94,16 +94,16 @@ function helpScreen(): string {
 		`  ${d("Score any site's agent readiness — and watch real AI agents navigate it")}`,
 		"",
 		`  ${d("Commands:")}`,
-		`    audit ${d("<url>")}       ${d("Score a site's agent readiness")}`,
+		`    scan ${d("<url>")}        ${d("Score a site's agent readiness")}`,
 		`    journey ${d("<intent>")}  ${d("Send a real agent at a site and watch it live")}`,
 		"",
 		`  ${d("Examples:")}`,
-		`    ${g} ${NAME} audit https://docs.example.com`,
-		`    ${g} ${NAME} audit https://docs.example.com --min-score 70`,
+		`    ${g} ${NAME} scan https://docs.example.com`,
+		`    ${g} ${NAME} scan https://docs.example.com --min-score 70`,
 		`    ${g} ${NAME} journey "Find the API docs and how to authenticate" --domain stripe.com`,
 		`    ${g} ${NAME} journey "Sign up for an account" --domain example.com --harness codex`,
 		"",
-		`  ${d("audit options:")}`,
+		`  ${d("scan options:")}`,
 		`    --json           ${d("Output as JSON")}`,
 		`    --min-score <n>  ${d("Exit 1 when the score is under n")}`,
 		`    --show-passing   ${d("List each passing check (hidden by default)")}`,
@@ -125,7 +125,7 @@ const root = defineCommand({
 		version: pkg.version,
 		description: "Score any site's agent readiness — and watch real AI agents navigate it",
 	},
-	subCommands: { audit, journey },
+	subCommands: { scan, journey },
 	setup() {
 		// Bare invocation and top-level --help get the curated screen; subcommand
 		// --help stays with citty's generated usage.

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,6 @@ const scan = defineCommand({
 			required: true,
 		},
 		json: { type: "boolean", description: "Output as JSON", default: false },
-		"min-score": { type: "string", description: "Exit 1 when the score is under n" },
 		"show-passing": {
 			type: "boolean",
 			description: "List each passing check individually",
@@ -31,20 +30,10 @@ const scan = defineCommand({
 		},
 	},
 	async run({ args }) {
-		let minScore: number | null = null;
-		if (args["min-score"] !== undefined) {
-			const parsed = Number(args["min-score"]);
-			if (!Number.isFinite(parsed)) {
-				console.error(`Invalid --min-score: ${args["min-score"]}`);
-				process.exit(2);
-			}
-			minScore = parsed;
-		}
 		process.exit(
 			await scanCommand({
 				url: args.url as string,
 				json: Boolean(args.json),
-				minScore,
 				showSkipped: Boolean(args["show-skipped"]),
 				showPassing: Boolean(args["show-passing"]),
 			}),
@@ -99,13 +88,12 @@ function helpScreen(): string {
 		"",
 		`  ${d("Examples:")}`,
 		`    ${g} ${NAME} scan https://docs.example.com`,
-		`    ${g} ${NAME} scan https://docs.example.com --min-score 70`,
+		`    ${g} ${NAME} scan https://docs.example.com --json`,
 		`    ${g} ${NAME} journey "Find the API docs and how to authenticate" --domain stripe.com`,
 		`    ${g} ${NAME} journey "Sign up for an account" --domain example.com --harness codex`,
 		"",
 		`  ${d("scan options:")}`,
 		`    --json           ${d("Output as JSON")}`,
-		`    --min-score <n>  ${d("Exit 1 when the score is under n")}`,
 		`    --show-passing   ${d("List each passing check (hidden by default)")}`,
 		`    --show-skipped   ${d("List skipped checks (hidden by default)")}`,
 		"",

--- a/src/report/json.test.ts
+++ b/src/report/json.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { auditReportJson } from "./json";
-import type { AuditReport } from "./model";
+import { reportJson } from "./json";
+import type { Report } from "./model";
 
-const REPORT: AuditReport = {
+const REPORT: Report = {
 	url: "https://acme.dev",
 	score: 75,
 	rating: "Good",
@@ -38,9 +38,9 @@ const REPORT: AuditReport = {
 	],
 };
 
-describe("auditReportJson", () => {
+describe("reportJson", () => {
 	it("emits the full result with snake_cased category keys", () => {
-		const body = JSON.parse(auditReportJson(REPORT));
+		const body = JSON.parse(reportJson(REPORT));
 		expect(body.url).toBe("https://acme.dev");
 		expect(body.score).toBe(75);
 		expect(body.rating).toBe("Good");
@@ -50,7 +50,7 @@ describe("auditReportJson", () => {
 	});
 
 	it("includes every check — passed, failed, and skipped — regardless of view flags", () => {
-		const body = JSON.parse(auditReportJson(REPORT));
+		const body = JSON.parse(reportJson(REPORT));
 		const checks = body.categories.agent_access.checks;
 		expect(checks).toHaveLength(4);
 		expect(checks[2]).toMatchObject({
@@ -67,11 +67,11 @@ describe("auditReportJson", () => {
 	});
 
 	it("slugs multi-word and punctuated section names", () => {
-		const twisted: AuditReport = {
+		const twisted: Report = {
 			...REPORT,
 			sections: [{ ...REPORT.sections[0], name: "  Découverte & Reach!  " }],
 		};
-		const body = JSON.parse(auditReportJson(twisted));
+		const body = JSON.parse(reportJson(twisted));
 		expect(Object.keys(body.categories)).toEqual(["d_couverte_reach"]);
 	});
 });

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -1,4 +1,4 @@
-import type { AuditReport } from "./model";
+import type { Report } from "./model";
 
 // The machine-readable result. Deliberately complete: every check — passing,
 // failing, or skipped — is present no matter which --show-* flags were given,
@@ -11,7 +11,7 @@ function slugOf(name: string): string {
 		.replace(/^_|_$/g, "");
 }
 
-export function auditReportJson(report: AuditReport): string {
+export function reportJson(report: Report): string {
 	const body = {
 		url: report.url,
 		score: report.score,

--- a/src/report/model.test.ts
+++ b/src/report/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ScanResult } from "../api/scan";
-import { type AuditCheck, ratingFor, sectionOf, toAuditReport } from "./model";
+import { type ReportCheck, ratingFor, sectionOf, toReport } from "./model";
 
 const SCAN: ScanResult = {
 	domain: "acme.dev",
@@ -60,11 +60,11 @@ const SCAN: ScanResult = {
 	],
 };
 
-const pick = (checks: AuditCheck[], name: string) => checks.find((c) => c.name === name);
+const pick = (checks: ReportCheck[], name: string) => checks.find((c) => c.name === name);
 
-describe("toAuditReport", () => {
+describe("toReport", () => {
 	it("turns layers into sections and keeps score + rating", () => {
-		const report = toAuditReport(SCAN, "https://acme.dev");
+		const report = toReport(SCAN, "https://acme.dev");
 		expect(report.url).toBe("https://acme.dev");
 		expect(report.score).toBe(82);
 		expect(report.rating).toBe("Good");
@@ -72,7 +72,7 @@ describe("toAuditReport", () => {
 	});
 
 	it("counts pass/fail/skip with na+pending excluded and warning as a failure", () => {
-		const [section] = toAuditReport(SCAN, "x").sections;
+		const [section] = toReport(SCAN, "x").sections;
 		expect(section.passed).toBe(1);
 		expect(section.total).toBe(3); // mcp endpoint (na) is out of the denominator
 		expect(section.skipped).toBe(1);
@@ -81,7 +81,7 @@ describe("toAuditReport", () => {
 	});
 
 	it("keeps the raw status, estScoreGain, and summary", () => {
-		const report = toAuditReport(SCAN, "x");
+		const report = toReport(SCAN, "x");
 		expect(report.summary).toBe("acme.dev greets agents well but hides its spec.");
 		const checks = report.sections[0].checks;
 		expect(pick(checks, "agent gateway")?.status).toBe("pass");
@@ -90,7 +90,7 @@ describe("toAuditReport", () => {
 	});
 
 	it("takes the fix from `recommendation`, never from `description`", () => {
-		const checks = toAuditReport(SCAN, "x").sections[0].checks;
+		const checks = toReport(SCAN, "x").sections[0].checks;
 		const mirror = pick(checks, "markdown mirror");
 		expect(mirror?.detail).toBe("0 of 12 pages mirrored");
 		expect(mirror?.hint).toBe("Serve a .md variant of each documentation page");
@@ -100,17 +100,17 @@ describe("toAuditReport", () => {
 	});
 
 	it("derives tiers from each check's weight within its layer", () => {
-		const checks = toAuditReport(SCAN, "x").sections[0].checks;
+		const checks = toReport(SCAN, "x").sections[0].checks;
 		expect(pick(checks, "agent gateway")?.tier).toBe("required"); // 10/10
 		expect(pick(checks, "markdown mirror")?.tier).toBe("recommended"); // 6/10
 		expect(pick(checks, "crawler policy")?.tier).toBe("recommended"); // 4/10
 	});
 
 	it("clamps scores into 0-100 and falls back to the requested URL", () => {
-		expect(toAuditReport({ score: 140, layers: [] }, "x").score).toBe(100);
-		expect(toAuditReport({ score: -5, layers: [] }, "x").score).toBe(0);
-		expect(toAuditReport({ score: 50 }, "https://asked.example").url).toBe("https://asked.example");
-		expect(toAuditReport({ score: 50, layers: [] }, "x").sections).toEqual([]);
+		expect(toReport({ score: 140, layers: [] }, "x").score).toBe(100);
+		expect(toReport({ score: -5, layers: [] }, "x").score).toBe(0);
+		expect(toReport({ score: 50 }, "https://asked.example").url).toBe("https://asked.example");
+		expect(toReport({ score: 50, layers: [] }, "x").sections).toEqual([]);
 	});
 });
 
@@ -128,7 +128,7 @@ describe("ratingFor", () => {
 });
 
 describe("sectionOf", () => {
-	const entry = (name: string, passed: boolean, skipped = false): AuditCheck => ({
+	const entry = (name: string, passed: boolean, skipped = false): ReportCheck => ({
 		name,
 		passed,
 		skipped: skipped || undefined,

--- a/src/report/model.ts
+++ b/src/report/model.ts
@@ -8,7 +8,7 @@ export type CheckTier = "required" | "recommended" | "optional";
 
 export const TIER_RANK: Record<CheckTier, number> = { required: 0, recommended: 1, optional: 2 };
 
-export interface AuditCheck {
+export interface ReportCheck {
 	name: string;
 	passed: boolean;
 	skipped?: boolean;
@@ -24,9 +24,9 @@ export interface AuditCheck {
 	estScoreGain?: number;
 }
 
-export interface AuditSection {
+export interface ReportSection {
 	name: string;
-	checks: AuditCheck[];
+	checks: ReportCheck[];
 	/** Passing count among non-skipped checks. */
 	passed: number;
 	/** Non-skipped check count. */
@@ -34,13 +34,13 @@ export interface AuditSection {
 	skipped: number;
 }
 
-export interface AuditReport {
+export interface Report {
 	url: string;
 	score: number;
 	rating: string;
 	/** ora's one-line agentic verdict, when it arrived. */
 	summary?: string;
-	sections: AuditSection[];
+	sections: ReportSection[];
 }
 
 export function ratingFor(score: number): string {
@@ -50,7 +50,7 @@ export function ratingFor(score: number): string {
 	return "Needs Improvement";
 }
 
-export function sectionOf(name: string, checks: AuditCheck[]): AuditSection {
+export function sectionOf(name: string, checks: ReportCheck[]): ReportSection {
 	const counted = checks.filter((c) => !c.skipped);
 	return {
 		name,
@@ -74,13 +74,13 @@ function tierOf(weight: number, heaviest: number): CheckTier {
 	return "optional";
 }
 
-function convertCheck(raw: ScanCheck, heaviest: number): AuditCheck {
+function convertCheck(raw: ScanCheck, heaviest: number): ReportCheck {
 	// pass → passed; na/pending → skipped (kept out of every count);
 	// fail/warning/error all surface as issues (warning just gets a softer glyph).
 	const passed = raw.status === "pass";
 	const skipped = raw.status === "na" || raw.status === "pending";
 
-	const check: AuditCheck = {
+	const check: ReportCheck = {
 		name: raw.name,
 		passed,
 		tier: tierOf(raw.maxScore ?? 0, heaviest),
@@ -95,7 +95,7 @@ function convertCheck(raw: ScanCheck, heaviest: number): AuditCheck {
 	return check;
 }
 
-export function toAuditReport(scan: ScanResult, requestedUrl: string): AuditReport {
+export function toReport(scan: ScanResult, requestedUrl: string): Report {
 	const sections = (scan.layers ?? []).map((layer) => {
 		const heaviest = layer.checks.reduce((top, c) => Math.max(top, c.maxScore ?? 0), 0);
 		return sectionOf(

--- a/src/report/terminal.ts
+++ b/src/report/terminal.ts
@@ -1,5 +1,5 @@
 import pc from "picocolors";
-import { type AuditCheck, type AuditReport, type AuditSection, TIER_RANK } from "./model";
+import { type Report, type ReportCheck, type ReportSection, TIER_RANK } from "./model";
 
 // Layered terminal report: a scored header, one block per layer with a pass
 // bar, and a bordered issues grid sorted by estimated score gain. All wrapping
@@ -141,17 +141,17 @@ function meter(passed: number, total: number): string {
 }
 
 // Biggest estimated gain first; equal gains fall back to tier importance.
-function byImpact(a: AuditCheck, b: AuditCheck): number {
+function byImpact(a: ReportCheck, b: ReportCheck): number {
 	const delta = (b.estScoreGain ?? 0) - (a.estScoreGain ?? 0);
 	return delta !== 0 ? delta : TIER_RANK[a.tier] - TIER_RANK[b.tier];
 }
 
-function byTier(a: AuditCheck, b: AuditCheck): number {
+function byTier(a: ReportCheck, b: ReportCheck): number {
 	return TIER_RANK[a.tier] - TIER_RANK[b.tier];
 }
 
 function sectionLines(
-	section: AuditSection,
+	section: ReportSection,
 	term: number,
 	label: number,
 	view: ReportView,
@@ -221,7 +221,7 @@ function sectionLines(
 	return lines;
 }
 
-export function renderAuditReport(report: AuditReport, view: ReportView = {}): string[] {
+export function renderReport(report: Report, view: ReportView = {}): string[] {
 	const term = reportWidth();
 	const label = report.sections.reduce((widest, s) => Math.max(widest, s.name.length), 0);
 

--- a/src/ui/ansi.ts
+++ b/src/ui/ansi.ts
@@ -31,7 +31,7 @@ export function flow(value: string, max: number): string[] {
 }
 
 /**
- * Pulse frames shared by the audit spinner and the journey panel — a breathing
+ * Pulse frames shared by the scan spinner and the journey panel — a breathing
  * diamond, echoing the ◆ intent marker in the journey graph. Every frame is a
  * single-cell glyph so `.length` math stays valid; frames are doubled so the
  * pulse breathes smoothly at the 80ms tick.

--- a/src/ui/spinner.ts
+++ b/src/ui/spinner.ts
@@ -1,7 +1,7 @@
 import pc from "picocolors";
 import { SPINNER_FRAMES } from "./ansi";
 
-// Single-line progress indicator on stderr, used while an audit scan streams.
+// Single-line progress indicator on stderr, used while a scan streams.
 // It only animates when stderr is an interactive terminal; in pipes and CI the
 // carriage-return repaint would otherwise show up as one line per tick.
 


### PR DESCRIPTION
## Summary

Follow-up to #1 (merged just before these commits were pushed). Two changes:

**`audit` → `scan`.** Renames the command across the CLI surface (subcommand, help screen, error prefix), the report-model identifiers (`Report`/`ReportSection`/`ReportCheck`, `toReport`, `renderReport`, `reportJson`), `src/commands/audit.ts` → `src/commands/scan.ts`, README, `.env.example`, mock-server hints, and the npm keyword. The `--json` output schema is unchanged.

**Remove `--min-score` (for now).** The flag, its validation, the below-threshold exit-1 path, and all docs/help references are gone; `scan` now exits `0` on any completed scan and `2` on error. Journey exit codes are untouched (`1` = non-success outcome). Easy to reintroduce later as a CI gate once scoring stabilizes.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm vitest run` — 42/42
- [x] Rebuilt `dist/main.cjs`; help + `scan --help` show the reduced flag set; mock-server scan renders identically; `--json` schema verified
- [x] Repo-wide grep: zero remaining `audit` or `min-score` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)