### PR TITLE
Update the documented harness roster (drop tavily, add current harnesses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Edges come from ora's own per-step attribution (link-follows nest under the page
 | Flag | Effect |
 |---|---|
 | `--domain <d>` | Site the agent targets (e.g. `stripe.com`) |
-| `--harness <h>` | Agent harness: `claude-code` (default), `codex`, `aider`, `openai-web`, `claude-web`, `tavily` |
+| `--harness <h>` | Agent harness: `claude-code` (default), `codex`, `aider`, `openai-web`, `claude-web` |
 | `--model <m>` | Model override (e.g. `claude-haiku-4-5-20251001` — cheap and good for demos) |
 | `--json` | Full result as JSON: run metadata, usage, insight, and the raw trajectory |
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Edges come from ora's own per-step attribution (link-follows nest under the page
 | Flag | Effect |
 |---|---|
 | `--domain <d>` | Site the agent targets (e.g. `stripe.com`) |
-| `--harness <h>` | Agent harness: `claude-code` (default), `codex`, `aider`, `openai-web`, `claude-web` |
+| `--harness <h>` | Agent harness: `claude-code` (default), `codex`, `openclaw`, `hermess`, `claude-agent`, `eve`, … |
 | `--model <m>` | Model override (e.g. `claude-haiku-4-5-20251001` — cheap and good for demos) |
 | `--json` | Full result as JSON: run metadata, usage, insight, and the raw trajectory |
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ const journey = defineCommand({
 		domain: { type: "string", description: "Site the agent targets (e.g. stripe.com)" },
 		harness: {
 			type: "string",
-			description: "Agent harness: claude-code, codex, aider, …",
+			description: "Agent harness: claude-code, codex, openclaw, hermess, claude-agent, eve, …",
 			default: "claude-code",
 		},
 		model: { type: "string", description: "Model override (harness default when omitted)" },
@@ -99,7 +99,7 @@ function helpScreen(): string {
 		"",
 		`  ${d("journey options:")}`,
 		`    --domain <d>     ${d("Site the agent targets (e.g. stripe.com)")}`,
-		`    --harness <h>    ${d("Agent harness: claude-code, codex, aider, … (default claude-code)")}`,
+		`    --harness <h>    ${d("Agent harness: claude-code (default), codex, openclaw, hermess, claude-agent, eve, …")}`,
 		`    --model <m>      ${d("Model override (harness default when omitted)")}`,
 		`    --json           ${d("Output as JSON")}`,
 		`    ${d("requires ORA_API_KEY (see .env.example)")}`,


### PR DESCRIPTION
## Summary

Docs/help refresh of the `--harness` options — the code never validates the value (it passes straight through to the API), so both commits are presentation-only:

- Drop `tavily` from the README's journey flag table.
- Replace the stale `aider` / `openai-web` / `claude-web` set with the current roster everywhere it's listed (README table, `journey --help` arg description, no-arg help screen): **`claude-code` (default), `codex`, `openclaw`, `hermess`, `claude-agent`, `eve`, …**

## Test plan

- [x] `pnpm lint` + `pnpm typecheck` clean; rebuilt `dist/main.cjs`
- [x] Help screen and `journey --help` show the new roster
- [x] Repo-wide grep: no `tavily`/`aider`/`openai-web`/`claude-web` mentions remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)