### PR TITLE
Add CI and manual-dispatch release pipeline for npm publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  # Everything here is a devDependency — the CLI ships as one bundled file with
+  # no runtime deps — so routine bumps are grouped into a single reviewable PR.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dev-minor-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # Keeps the SHA-pinned actions in .github/workflows current. Pinning without
+  # this is how a workflow quietly rots on an unmaintained action version.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Least privilege: CI only ever reads the repo.
+permissions:
+  contents: read
+
+# A newer push to the same branch makes the in-flight run irrelevant.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Version used for every single-version job. The test matrix below covers the
+  # full range that package.json `engines` promises.
+  NODE_VERSION: "22"
+
+jobs:
+  quality:
+    name: Lint & Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Must precede setup-node: `cache: pnpm` needs the pnpm binary on PATH.
+      # Version comes from the package.json `packageManager` field.
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+  test:
+    name: Test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      # One Node version failing shouldn't hide the result on the others.
+      fail-fast: false
+      matrix:
+        # Floor is package.json `engines.node`; the rest are current LTS/latest.
+        node: ["20", "22", "24"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm test:ci
+
+  build:
+    name: Build & Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      # Runs the bundled binary the way a user would. Catches the failures unit
+      # tests structurally cannot: bad shebang, lost executable bit, stale version.
+      - name: Smoke test bundled CLI
+        run: pnpm smoke
+
+      # Proves the tarball npm would publish actually contains a usable bin —
+      # an unbuilt dist publishes silently and is expensive to discover later.
+      - name: Verify publishable tarball
+        run: pnpm verify:pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,200 @@
+name: Release
+
+# Publishing is a deliberate act: manual dispatch only, from main only.
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: "Semver bump to apply before publishing"
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+          # Publishes package.json's current version untouched. Needed for the
+          # very first release (so 0.1.0 ships as 0.1.0), and to retry a release
+          # that died after the bump commit landed.
+          - none
+      dry_run:
+        description: "Rehearse only — build and validate, publish and push nothing"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Never cancel a release mid-flight; a half-finished publish is the one state
+# with no clean recovery.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the bump commit + tag, create the GitHub Release
+      id-token: write # OIDC token for npm provenance attestation
+    steps:
+      - name: Guard — releases ship from main only
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Release must be dispatched from main (got ${{ github.ref }})"
+          exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history + tags: the preflight check needs to see existing tags.
+          fetch-depth: 0
+          # Credentials are kept (unlike CI) — this job pushes.
+          persist-credentials: true
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - run: pnpm install --frozen-lockfile
+
+      # Re-run the full gate here rather than trusting a green CI run on the same
+      # SHA: dispatch can happen long after CI, and npm versions are forever.
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test:ci
+
+      - name: Resolve release version
+        id: version
+        env:
+          BUMP: ${{ inputs.version_bump }}
+        run: |
+          set -euo pipefail
+          if [ "$BUMP" = "none" ]; then
+            version=$(node -p "require('./package.json').version")
+            echo "Publishing current version unchanged: $version"
+          else
+            version=$(npm version "$BUMP" --no-git-tag-version | sed 's/^v//')
+            echo "Bumped ($BUMP) -> $version"
+          fi
+          {
+            echo "version=$version"
+            echo "tag=v$version"
+            echo "name=$(node -p "require('./package.json').name")"
+          } >> "$GITHUB_OUTPUT"
+
+      # Fail before publishing rather than halfway through it.
+      - name: Preflight — tag and registry collision check
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          PKG: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG already exists — pick a different bump"
+            exit 1
+          fi
+          if npm view "$PKG@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::$PKG@$VERSION is already on npm — versions cannot be reused"
+            exit 1
+          fi
+          echo "Clear to publish $PKG@$VERSION as $TAG"
+
+      # Strictly after the bump: tsup inlines package.json, so building earlier
+      # would ship a binary that reports the previous version.
+      - name: Build
+        run: pnpm build
+
+      - name: Smoke test bundled CLI
+        run: pnpm smoke
+
+      # Catches publishing an unbuilt or truncated bundle — npm would accept it
+      # silently and break every `npx @ora-ai/ax`. Last chance while the version
+      # is still free; once published it can never be reused.
+      - name: Verify publishable tarball
+        run: pnpm verify:pack
+
+      - name: Publish to npm
+        env:
+          # Swap for OIDC Trusted Publishing later — see RELEASING.md. The
+          # id-token permission this job already holds is the only other
+          # requirement, so the migration is deleting these two lines.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            # No --provenance: attestations require a real publish to sign.
+            npm publish --access public --dry-run
+          else
+            npm publish --access public --provenance
+          fi
+
+      # Push only after npm accepted the publish. npm versions are immutable and
+      # effectively unrecoverable; a local commit and tag cost nothing to discard.
+      # If this step fails, npm has the release and git does not — see RELEASING.md.
+      - name: Commit, tag and push
+        if: ${{ !inputs.dry_run }}
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # `none` leaves package.json untouched, so there is nothing to commit.
+          if git diff --quiet -- package.json; then
+            echo "No version change to commit; tagging current HEAD"
+          else
+            git add package.json
+            git commit -m "chore(release): $TAG [skip ci]"
+          fi
+
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin HEAD:main
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: gh release create "$TAG" --title "$TAG" --generate-notes --verify-tag
+
+      - name: Summary
+        if: always()
+        env:
+          PKG: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+          BUMP: ${{ inputs.version_bump }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          {
+            echo "## Release ${TAG:-(not reached)}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Package | \`${PKG:-?}\` |"
+            echo "| Version | \`${VERSION:-?}\` |"
+            echo "| Bump | \`$BUMP\` |"
+            echo "| Dry run | \`$DRY_RUN\` |"
+            echo "| Result | ${{ job.status }} |"
+            echo ""
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "Rehearsal only — nothing was published, committed or tagged."
+            else
+              echo "https://www.npmjs.com/package/${PKG:-}/v/${VERSION:-}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ pnpm test:ci         # single run + coverage
 pnpm typecheck
 pnpm lint
 pnpm build           # tsup → dist/main.cjs (single self-contained binary)
+pnpm smoke           # run the built binary the way a user would (needs build)
+pnpm verify:pack     # check the tarball npm would publish (needs build)
 node dist/main.cjs scan https://example.com
 ```
 
@@ -144,6 +146,12 @@ ORA_API_URL=http://localhost:8799 node dist/main.cjs scan https://stripe.com
 ```
 
 To exercise the published-package experience locally: `npm pack`, then `npx ./ora-ai-ax-0.1.0.tgz scan https://example.com`, or `pnpm link --global` and use `ax` directly.
+
+## Releasing
+
+Publishing runs from GitHub Actions only — **Actions → Release → Run workflow**,
+pick a `patch`/`minor`/`major` bump. See [RELEASING.md](RELEASING.md) for the
+runbook, required setup, and failure recovery.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,109 @@
+# Releasing `@ora-ai/ax`
+
+Releases are manual, deliberate, and run entirely in CI. Nobody publishes from a
+laptop.
+
+## Cutting a release
+
+1. Land your changes on `main` and let [CI](.github/workflows/ci.yml) go green.
+2. **Actions → Release → Run workflow**, from the `main` branch.
+3. Pick a `version_bump`:
+   - `patch` — bug fixes
+   - `minor` — new commands or flags, backwards compatible
+   - `major` — breaking changes to commands, flags, or output
+   - `none` — publish `package.json`'s current version as-is
+4. Leave `dry_run` unchecked. Run it.
+
+The workflow lints, typechecks, tests, bumps, builds, smoke-tests the bundled
+binary, publishes to npm with provenance, then commits `chore(release): vX.Y.Z`,
+tags it, and opens a GitHub Release with generated notes.
+
+Rehearse anything uncertain with `dry_run` checked: it does every step including
+`npm publish --dry-run`, but publishes nothing, commits nothing, pushes nothing.
+
+## One-time setup
+
+### `NPM_TOKEN`
+
+Create a **granular access token** on npmjs.com with read+write on the `@ora-ai`
+scope, then:
+
+```sh
+gh secret set NPM_TOKEN --repo eralabs-ai/ora-cli
+```
+
+Granular tokens bypass 2FA prompts, which is what makes automated publishing
+work. Give it an expiry and diarise the rotation.
+
+### npm org
+
+The `@ora-ai` scope must exist on npmjs.com and the token's account needs publish
+rights on it. The scope is unclaimed as of the first release — claim it before
+someone else does.
+
+## The first release
+
+`package.json` is at `0.1.0` and nothing is published yet. Any bump would skip
+`0.1.0` and make `0.1.1` your first version. To ship `0.1.0` itself, run the
+workflow with **`version_bump: none`**.
+
+## When something goes wrong
+
+The workflow publishes to npm **before** it pushes to git, on purpose: npm
+versions are immutable and effectively permanent, while a local commit and tag
+cost nothing to throw away. That shapes recovery:
+
+**Failed before or during publish** — nothing was pushed and nothing reached npm.
+Fix the cause and re-run. The bump lived only in the runner's working copy.
+
+**Published, but the push failed** — npm has the release and git does not. This
+usually means `main` moved between checkout and push. Reconcile by hand:
+
+```sh
+git checkout main && git pull
+npm version <the-published-version> --no-git-tag-version
+git commit -am "chore(release): v<the-published-version>"
+git tag -a "v<the-published-version>" -m "Release v<the-published-version>"
+git push origin main --follow-tags
+gh release create "v<the-published-version>" --generate-notes --verify-tag
+```
+
+Do **not** re-run the Release workflow to fix this — the preflight check will
+correctly refuse, because that version is already on npm.
+
+**Wrong version published** — you cannot reuse or overwrite a version. Publish
+the fix forward under a new version. `npm deprecate` the bad one with a message
+pointing at the replacement.
+
+## Migrating to OIDC Trusted Publishing
+
+Trusted Publishing removes the long-lived `NPM_TOKEN` entirely: npm verifies the
+workflow's identity through GitHub's OIDC provider instead of a stored
+credential. It requires the package to already exist, which is why the first
+release uses a token.
+
+Once `@ora-ai/ax` is published:
+
+1. npmjs.com → the package → **Settings → Trusted Publisher** → GitHub Actions.
+   Set repository `eralabs-ai/ora-cli` and workflow `release.yml`.
+2. In [`.github/workflows/release.yml`](.github/workflows/release.yml), delete
+   the `NODE_AUTH_TOKEN` line from the *Publish to npm* step (and the comment
+   above it). Everything else already works — the job holds `id-token: write`
+   and publishes with `--provenance`.
+3. Verify with a `dry_run`, then cut a real patch release.
+4. Delete the `NPM_TOKEN` secret and revoke the token on npmjs.com.
+
+## If you protect `main`
+
+The release job pushes its bump commit and tag directly to `main` using the
+built-in `GITHUB_TOKEN`. `main` is currently unprotected, so this works as-is.
+If you add branch protection, that push starts failing — grant the exception via
+a bypass allowance for GitHub Actions in the ruleset, or swap the checkout token
+for a PAT that can bypass it.
+
+## Optional hardening
+
+Add a protected [environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments)
+named `npm` with required reviewers, and set `environment: npm` on the `release`
+job. Publishing then needs a second person to approve the run. Worth doing once
+more than one maintainer can dispatch releases.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
 	},
 	"scripts": {
 		"build": "rm -rf dist && tsup",
+		"smoke": "node scripts/smoke.mjs",
+		"verify:pack": "node scripts/verify-pack.mjs",
 		"test": "vitest",
 		"test:ci": "vitest run --coverage",
 		"lint": "biome check .",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Post-build smoke test for the bundled CLI.
+//
+// tsup inlines package.json at build time (src/main.ts imports it), so a build
+// that ran *before* a version bump would publish a binary whose `ax --version`
+// lies. The release workflow bumps then builds; this asserts that ordering held.
+// Also checks the things that break `npx @ora-ai/ax` but never break `pnpm test`:
+// a missing shebang or a non-executable bin.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+
+const BIN = "dist/main.cjs";
+const failures = [];
+
+function check(label, fn) {
+	try {
+		fn();
+		console.log(`  ok    ${label}`);
+	} catch (error) {
+		failures.push(`${label}: ${error.message}`);
+		console.log(`  FAIL  ${label}`);
+	}
+}
+
+function ax(args) {
+	return execFileSync(process.execPath, [BIN, ...args], { encoding: "utf8" }).trim();
+}
+
+const expectedVersion = JSON.parse(readFileSync("package.json", "utf8")).version;
+
+console.log(`smoke: ${BIN} (expecting v${expectedVersion})`);
+
+check("bin is executable", () => {
+	const mode = statSync(BIN).mode;
+	if (!(mode & 0o111)) throw new Error("missing executable bit");
+});
+
+check("bin has a node shebang", () => {
+	const head = readFileSync(BIN, "utf8").slice(0, 32);
+	if (!head.startsWith("#!/usr/bin/env node")) throw new Error(`starts with ${head.slice(0, 20)}`);
+});
+
+check("--version matches package.json", () => {
+	const actual = ax(["--version"]);
+	if (actual !== expectedVersion) throw new Error(`got "${actual}", want "${expectedVersion}"`);
+});
+
+check("--help exits 0 and lists both commands", () => {
+	const help = ax(["--help"]);
+	for (const command of ["scan", "journey"]) {
+		if (!help.includes(command)) throw new Error(`help omits "${command}"`);
+	}
+});
+
+check("scan --help exits 0", () => ax(["scan", "--help"]));
+check("journey --help exits 0", () => ax(["journey", "--help"]));
+
+if (failures.length > 0) {
+	console.error(`\nsmoke failed (${failures.length}):`);
+	for (const failure of failures) console.error(`  - ${failure}`);
+	process.exit(1);
+}
+
+console.log("\nsmoke passed");

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -42,8 +42,14 @@ check("bin has a node shebang", () => {
 });
 
 check("--version matches package.json", () => {
-	const actual = ax(["--version"]);
-	if (actual !== expectedVersion) throw new Error(`got "${actual}", want "${expectedVersion}"`);
+	// citty prints through consola, which tags lines as "[log] 0.1.0" whenever CI
+	// is set and prints a bare "0.1.0" otherwise. Match the semver rather than the
+	// whole line so this asserts the same thing on a laptop and on a runner.
+	const raw = ax(["--version"]);
+	const actual = raw.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0];
+	if (actual !== expectedVersion) {
+		throw new Error(`got ${JSON.stringify(raw)}, want "${expectedVersion}"`);
+	}
 });
 
 check("--help exits 0 and lists both commands", () => {

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Verifies the publishable tarball before it reaches npm.
+//
+// The failure this exists to catch is publishing without a build: `npm publish`
+// happily ships a tarball with no `dist/`, and the broken version can never be
+// reused. npm force-includes the `bin` target even when `files` omits it, so a
+// present-and-sane bin is a direct proxy for "the build actually ran".
+//
+// Also asserts no real .env slips in alongside .env.example.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+// A truncated or empty bundle would still be "present". The real bundle is
+// ~110KB; this floor only catches something that went badly wrong.
+const MIN_BIN_BYTES = 1024;
+
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+
+const stdout = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+	encoding: "utf8",
+	stdio: ["ignore", "pipe", "inherit"],
+});
+
+const [tarball] = JSON.parse(stdout);
+const byPath = new Map(tarball.files.map((file) => [file.path, file]));
+
+console.log(
+	`tarball: ${tarball.name}@${tarball.version} — ${tarball.entryCount} files, ${tarball.size} bytes`,
+);
+for (const file of tarball.files) console.log(`  ${file.path} (${file.size} bytes)`);
+
+const problems = [];
+
+for (const [name, target] of Object.entries(pkg.bin)) {
+	const path = target.replace(/^\.\//, "");
+	const entry = byPath.get(path);
+
+	if (!entry) {
+		problems.push(`bin "${name}" -> ${path} is missing — did the build run?`);
+		continue;
+	}
+	if (entry.size < MIN_BIN_BYTES) {
+		problems.push(
+			`bin "${name}" -> ${path} is only ${entry.size} bytes; the build looks truncated`,
+		);
+	}
+	if (!(entry.mode & 0o111)) {
+		problems.push(`bin "${name}" -> ${path} is not executable (mode ${entry.mode.toString(8)})`);
+	}
+}
+
+// .env.example is intentionally shipped; a real .env never should be.
+for (const path of byPath.keys()) {
+	if (path === ".env" || (path.startsWith(".env.") && path !== ".env.example")) {
+		problems.push(`${path} must not be published`);
+	}
+}
+
+if (problems.length > 0) {
+	console.error(`\npack verification failed (${problems.length}):`);
+	for (const problem of problems) console.error(`  - ${problem}`);
+	process.exit(1);
+}
+
+console.log("\npack verified");


### PR DESCRIPTION
Sets up GitHub Actions for `@ora-ai/ax`: a CI gate on every PR, and a manual **Release** workflow that bumps, publishes to npm with provenance, tags, and opens a GitHub Release.

Shaped after `dag7/ironplate`'s dispatch UX (`version_bump` choice + `dry_run`), adapted to npm — where `package.json` is the version source of truth rather than git tags.

## What's here

| File | |
|---|---|
| `.github/workflows/ci.yml` | lint + typecheck, tests on Node 20/22/24, build + artifact checks |
| `.github/workflows/release.yml` | `workflow_dispatch` → bump, publish, tag, GitHub Release |
| `.github/dependabot.yml` | weekly npm + github-actions, grouped |
| `scripts/smoke.mjs` | runs the built binary the way a user would |
| `scripts/verify-pack.mjs` | inspects the tarball npm would publish |
| `RELEASING.md` | runbook: setup, first release, recovery, OIDC migration |

## Two ordering constraints drove the design

**Build strictly after the bump.** `src/main.ts` imports `package.json` and tsup inlines it at build time, so building before the bump ships a binary whose `ax --version` lies. `scripts/smoke.mjs` asserts the two agree — verified it fails on a stale build:

```
FAIL  --version matches package.json
  - got "0.1.0", want "0.1.1"
```

**Publish before pushing to git.** npm versions are immutable and effectively unrecoverable; a local commit and tag cost nothing to discard. So a failed publish leaves no orphan tag, and the single bad case — published but push failed — fails loudly with a documented manual fix.

## The `none` bump option

`@ora-ai/ax` is at `0.1.0` and unpublished, so any bump would skip it and make `0.1.1` the first release. `none` publishes `package.json` as-is. It also covers retrying a release that died after the bump.

## A finding worth flagging

npm **force-includes** the `bin` target even when `files` omits it, so "is the bin in the tarball?" can't fail that way. The check earns its place against a different failure: an unbuilt or truncated `dist`, which npm accepts silently and which breaks every `npx @ora-ai/ax`. `verify-pack.mjs` checks presence, size, and the executable bit, and refuses to ship a real `.env`.

## Verification

Everything the workflows run, run locally — all green:

```
OK  lint          OK  build         OK  actionlint
OK  typecheck     OK  smoke
OK  test:ci       OK  verify:pack
```

Both guards were negative-tested (stale build → exit 1; unbuilt dist → exit 1; leaked `.env` → exit 1).

## Before the first release

1. **`NPM_TOKEN`** — granular access token, read+write on `@ora-ai`:
   `gh secret set NPM_TOKEN --repo eralabs-ai/ora-cli`
2. **Claim the `@ora-ai` npm org** — currently unclaimed; publish rights required.
3. Run **Release** with `version_bump: none` to ship `0.1.0`.

Default branch is already `main`, and `main` is unprotected so the release push works as-is — `RELEASING.md` covers what changes if that's protected later.

Auth is `NPM_TOKEN` for now, with `id-token: write` already granted for provenance — migrating to OIDC Trusted Publishing is deleting one line once the package exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)