### PR TITLE
Fix: normalise package.json formatting after the release bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ jobs:
     permissions:
       contents: write # push the bump commit + tag, create the GitHub Release
       id-token: write # OIDC token for npm provenance attestation
+    env:
+      # setup-node writes an .npmrc referencing ${NODE_AUTH_TOKEN}, so every npm and
+      # pnpm call warns until something defines it. The publish step overrides this
+      # with the real token; an empty default just keeps the secret scoped there
+      # while removing a warning that otherwise buries real errors in the log.
+      NODE_AUTH_TOKEN: ""
     steps:
       - name: Guard — releases ship from main only
         if: github.ref != 'refs/heads/main'
@@ -92,6 +98,18 @@ jobs:
             echo "tag=v$version"
             echo "name=$(node -p "require('./package.json').name")"
           } >> "$GITHUB_OUTPUT"
+
+      # `npm version` re-serialises package.json with npm's own formatting, which
+      # expands arrays that biome keeps inline. Without this, the release commits a
+      # file that fails `pnpm lint` — and since the gate above runs *before* the
+      # bump, the break only surfaces on the next release. Normalise, then re-run
+      # the linter over the bumped tree so it can never ship unformatted again.
+      - name: Normalise formatting after bump
+        if: inputs.version_bump != 'none'
+        run: |
+          set -euo pipefail
+          pnpm lint:fix
+          pnpm lint
 
       # Fail before publishing rather than halfway through it.
       - name: Preflight — tag and registry collision check
@@ -153,12 +171,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # `none` leaves package.json untouched, so there is nothing to commit.
-          if git diff --quiet -- package.json; then
-            echo "No version change to commit; tagging current HEAD"
+          # Stage everything tracked that changed — the bump plus any formatting the
+          # normalise step applied — so the commit can never be a partial snapshot
+          # of what was just published. .gitignore keeps dist/ and coverage/ out.
+          # `none` leaves the tree untouched, so there is nothing to commit.
+          if git diff --quiet HEAD; then
+            echo "No changes to commit; tagging current HEAD"
           else
-            git add package.json
+            git add -A
             git commit -m "chore(release): $TAG [skip ci]"
+            echo "Committed:"
+            git show --stat --oneline HEAD | tail -n +2
           fi
 
           git tag -a "$TAG" -m "Release $TAG"

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
 	"bin": {
 		"ax": "./dist/main.cjs"
 	},
-	"files": [
-		"dist",
-		".env.example"
-	],
+	"files": ["dist", ".env.example"],
 	"engines": {
 		"node": ">=20.0.0"
 	},
@@ -39,10 +36,7 @@
 		"access": "public"
 	},
 	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@biomejs/biome",
-			"esbuild"
-		]
+		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild"]
 	},
 	"license": "MIT",
 	"homepage": "https://ora.ai",


### PR DESCRIPTION
Unbreaks `main` and fixes the release pipeline bug that broke it. **Merge this before the next release.**

## What happened

The v0.1.1 release left `main` failing its own lint, and the next Release run died on it at step one.

`npm version` re-serialises `package.json` with npm's own formatting, expanding arrays that biome keeps inline:

```diff
-	"files": ["dist", ".env.example"],
+	"files": [
+		"dist",
+		".env.example"
+	],
```

Three things had to line up, and they all did:

1. The release gate lints **before** it bumps — so nothing saw the rewrite.
2. The release commit carries `[skip ci]`.
3. `ci.yml` now triggers on `pull_request` only, so nothing linted `main` after the push either.

The broken file sat on `main` until the next release hit `pnpm lint`. My bug — the ordering in the workflow I wrote.

## The fix

**Symptom:** `package.json` reformatted, `main` lints clean again.

**Cause:** `release.yml` normalises formatting after the bump, then **re-runs the linter over the bumped tree**, so an unformatted release commit can't be created:

```yaml
- name: Normalise formatting after bump
  if: inputs.version_bump != 'none'
  run: |
    pnpm lint:fix
    pnpm lint
```

**Related hole closed:** the commit step staged `package.json` alone. If the formatter touched anything else, that change would be published but left out of the commit — git wouldn't match what shipped. Now stages every tracked change (`.gitignore` keeps `dist/` and `coverage/` out).

**Log noise:** `NODE_AUTH_TOKEN` gets an empty job-level default. `setup-node` writes an `.npmrc` referencing it, so every npm/pnpm call warned until the publish step defined it — that warning sat directly above the real error in the failed run. The publish step still supplies the real token, so the secret stays scoped to the one step that needs it.

## Verification

Replayed the exact sequence locally:

| | |
|---|---|
| `npm version patch` alone → `pnpm lint` | **exit 1** — reproduces the reported error |
| bump → `lint:fix` → `lint` | **exit 0**, `"version": "0.1.2"` preserved, arrays inline |

Full gate green: lint, typecheck, 42 tests, build, smoke, verify:pack, actionlint.

## Note on #9

#9 (the dependency bumps) is unaffected by this — it passed CI because `pnpm add` rewrote `package.json` and happened to land on formatting biome 2 accepts. It'll want a rebase after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)