### PR TITLE
Load a local .env on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ node --env-file=.env dist/main.cjs journey "Find the pricing page" --domain exam
 
 All configuration is environment-first: the consumer defines the variables, the CLI only reads them.
 
+A `.env` in the working directory is read on startup — copy `.env.example` and fill it in. Anything already exported wins over the file, so a key set for your shell or by CI beats a stale `.env`.
+
 | Var | Used by | Default | Purpose |
 |---|---|---|---|
 | `ORA_API_URL` | scan | `https://ora.ai` | Public scan API base (no auth) |

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"files": ["dist", ".env.example"],
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=20.12.0"
 	},
 	"scripts": {
 		"build": "rm -rf dist && tsup",

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadLocalEnv } from "./env";
+
+// Every case runs inside a throwaway directory: `.env` is resolved from cwd, and
+// the repo's own .env holds a real key that must never leak into a test.
+describe("loadLocalEnv", () => {
+	const originalCwd = process.cwd();
+	const originalKey = process.env.ORA_API_KEY;
+	let dir: string | undefined;
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		if (dir) rmSync(dir, { recursive: true, force: true });
+		dir = undefined;
+		// loadEnvFile mutates process.env for real, so stub helpers cannot undo it.
+		// process.env stringifies whatever it is given, so biome's suggested
+		// `= undefined` stores the literal "undefined" and the next test reads it
+		// back as a key. delete is the only way to genuinely unset the variable.
+		// biome-ignore lint/performance/noDelete: assignment would store "undefined" as a string
+		if (originalKey === undefined) delete process.env.ORA_API_KEY;
+		else process.env.ORA_API_KEY = originalKey;
+	});
+
+	function inTempDir(contents?: string): void {
+		dir = mkdtempSync(join(tmpdir(), "ax-env-"));
+		if (contents !== undefined) writeFileSync(join(dir, ".env"), contents);
+		process.chdir(dir);
+	}
+
+	it("reads a local .env into the environment", () => {
+		inTempDir("ORA_API_KEY=from_file\n");
+		expect(loadLocalEnv()).toBe(true);
+		expect(process.env.ORA_API_KEY).toBe("from_file");
+	});
+
+	it("lets an exported variable win over the file", () => {
+		process.env.ORA_API_KEY = "from_environment";
+		inTempDir("ORA_API_KEY=from_file\n");
+
+		loadLocalEnv();
+
+		// A key exported for this shell beats a stale .env sitting in the directory.
+		expect(process.env.ORA_API_KEY).toBe("from_environment");
+	});
+
+	it("reports no load when the directory has no .env", () => {
+		inTempDir();
+		expect(loadLocalEnv()).toBe(false);
+		expect(process.env.ORA_API_KEY).toBe(originalKey);
+	});
+
+	it("survives a runtime without loadEnvFile instead of throwing", () => {
+		inTempDir("ORA_API_KEY=from_file\n");
+		const loader = process.loadEnvFile;
+		// Node gained loadEnvFile in 20.12; older runtimes must still start.
+		(process as { loadEnvFile?: unknown }).loadEnvFile = undefined;
+		try {
+			expect(loadLocalEnv()).toBe(false);
+		} finally {
+			process.loadEnvFile = loader;
+		}
+	});
+});

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,32 @@
+/**
+ * Loads a local `.env` into the environment, if one is there.
+ *
+ * The CLI already promised this everywhere but never did it: `.env.example`
+ * says "Copy to `.env` and fill in", the missing-key error points at "a local
+ * .env file", and `.env.example` even ships inside the published tarball — yet
+ * nothing ever read the file. Following those instructions produced
+ * "Missing ORA_API_KEY".
+ *
+ * Uses Node's built-in loader rather than a dependency: the CLI ships as one
+ * self-contained bundle with no runtime deps, and this keeps it that way.
+ *
+ * Reads only the current directory, matching what the docs describe and what
+ * dotenv does by default. Exported variables win over the file, so a key set
+ * for the shell or by CI beats a stale `.env` left in the directory.
+ *
+ * @returns whether a file was actually loaded.
+ */
+export function loadLocalEnv(): boolean {
+	// Node gained loadEnvFile in 20.12. `engines` asks for that, but engines is
+	// advisory — an older runtime should still start and fail later on the
+	// missing key, not die here with a TypeError.
+	if (typeof process.loadEnvFile !== "function") return false;
+
+	try {
+		process.loadEnvFile();
+		return true;
+	} catch {
+		// No .env here. The common case: `npx @ora-ai/ax scan` needs no config.
+		return false;
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import pc from "picocolors";
 import pkg from "../package.json";
 import { journeyCommand } from "./commands/journey";
 import { scanCommand } from "./commands/scan";
+import { loadLocalEnv } from "./env";
 
 const NAME = "ax";
 
@@ -124,5 +125,9 @@ const root = defineCommand({
 		}
 	},
 });
+
+// Before anything reads process.env — every command resolves its configuration
+// at call time, so the file has to be in place first.
+loadLocalEnv();
 
 runMain(root);


### PR DESCRIPTION
The CLI promised `.env` support in three places and delivered it in none.

- `.env.example`: *"Copy to `.env` and fill in"*
- The missing-key error: *"Set it in your environment **or a local .env file**"*
- `.env.example` even ships inside the published tarball

But nothing ever read the file. Following those instructions produced `Missing ORA_API_KEY`.

```
$ ls .env
.env                                    # valid key, 540 bytes

$ ax journey "…" --domain ora.ai
Journey failed: Missing ORA_API_KEY. Set it in your environment or a local .env file.
$ echo $?
2
```

## Approach

Uses Node's built-in `process.loadEnvFile()` rather than adding dotenv — this keeps the promise that the CLI is one self-contained bundle with no runtime dependencies. Zero bytes added.

## Semantics, each covered by a test

| Behaviour | Why |
|---|---|
| Reads `./.env` | Matches what the docs describe and what dotenv does by default |
| **Exported vars win over the file** | A key set for your shell or by CI beats a stale `.env` in the directory |
| Missing `.env` is not an error | `ax scan` needs no configuration at all |
| Runtime without `loadEnvFile` still starts | Fails later on the missing key, not with a `TypeError` |

`engines` moves to `>=20.12.0` — the release that added `loadEnvFile`. Since `engines` is only advisory, the runtime guard above is what actually protects older Node.

## Verification

End to end against the **live API**, key present only in `.env` with nothing exported — the exact case that failed before:

```
$ env -u ORA_API_KEY -u ORA_PLATFORM_URL node dist/main.cjs journey "…" --domain ora.ai
exit: 0        # completes, full report rendered
```

Gate green: lint, typecheck, **46 tests** (up from 42), build, smoke, verify:pack.

## One reviewer note

There's a `biome-ignore` in the test for `lint/performance/noDelete`. Biome's autofix rewrites `delete process.env.X` to `process.env.X = undefined`, which is **wrong for `process.env` specifically** — it stringifies, leaving the literal `"undefined"` as the value:

```
after assigning undefined -> "undefined" (type: string)
after delete            -> undefined
```

That would poison the test cleanup and leak a bogus key into later tests. `delete` is the only way to genuinely unset it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)