### PR TITLE
feat: ax deep-journey - run a public agent journey from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,43 @@ ax audit localhost:3000 --tunnel-cmd 'ngrok http 3000 --log stdout'
 - Off-site checks (registry listings, brand search) usually fail for a throwaway tunnel hostname — the report says so. Use tunnel audits to iterate on your on-site surface, not to compare scores.
 - Free tiers of some tunnel vendors serve an interstitial warning page to browser-like requests, which can distort what the scanner sees — prefer a vendor/plan that serves your origin directly.
 
+## deep-journey
+
+```
+ax deep-journey <url> [--intent id] [--agent id] [--no-stream] [--json]
+```
+
+```
+ax deep-journey stripe.com --intent pricing
+```
+
+Runs a real AI agent at a site on a curated task through ora's **public** journey API — no key, no workspace. The agent's trajectory streams live as progress lines; the terminal output is ora's verdict, the billable step count, and the generated insight:
+
+```
+  ✓ task satisfied  stripe.com
+  14 steps · 6 turns · 41.2s
+
+  The agent found the pricing page in two hops via llms.txt and correctly
+  summarised the standard and custom tiers.
+    - llms.txt was load-bearing: it linked /pricing directly
+    - no web search was needed; every path came from on-site links
+
+  For the 4-layer readiness audit, run: ax audit stripe.com
+```
+
+Curated intents only (`pricing`, `signup`, `api-docs`, `get started`, `support`, …) — list them with `GET https://ora.ai/api/journey/intents`, and the accepted agents with `GET https://ora.ai/api/journey/agents`. The public caps are 5 runs per rolling 24h per target and 10 runs per 24h per IP; a target at its cap answers with the most recent stored run (`rate_limited: true`) instead of an error, so repeat CI invocations are cheap. Verdict and step count come from ora's contract as-is — the CLI never re-judges a run.
+
+| Flag | Effect |
+|---|---|
+| `--intent <id>` | Curated task id (server default when omitted) |
+| `--agent <id>` | Agent from the public roster (default: ora's pick) |
+| `--no-stream` | Poll for the result instead of streaming the trajectory |
+| `--json` | Print the terminal run detail (verdict, step_count, result) as JSON |
+
+deep-journey exit codes: `0` run succeeded (any verdict) · `1` run failed · `2` usage error · `3` API unreachable / rate-limited.
+
+This differs from `ax journey` (below), which drives the authenticated platform with free-text goals and renders the full trajectory graph; `deep-journey` is the zero-setup public path.
+
 ## skill
 
 ```
@@ -167,6 +204,23 @@ console.log(result.score, result.grade, result.topFixes);
 
 `result` is the raw versioned audit payload (`AuditScanResult` / `AuditScoreResult`, generated from ora's OpenAPI spec). `fetchSkill` / `fetchSkillIndex` expose the digest-verified skill registry.
 
+The public journey client is exported too — the same no-key path as `ax deep-journey`:
+
+```ts
+import { deepJourney, fetchJourneyAgents } from "@ora-ai/ax";
+
+const { agents, defaultId } = await fetchJourneyAgents();
+const agent = agents.find((a) => a.id === defaultId)!;
+const { detail } = await deepJourney("stripe.com", {
+	intentId: "pricing",
+	harness: agent.harness,
+	model: agent.model,
+});
+console.log(detail.verdict, detail.step_count, detail.result?.insight.summary);
+```
+
+`detail` is the contract's `JourneyRunDetail`; `fetchJourneyIntents` lists the curated intents. The same public caps apply — a capped target resolves with the most recent stored run (`cached: true` on the outcome), not an error.
+
 ## Environment variables
 
 All configuration is environment-first: the consumer defines the variables, the CLI only reads them.
@@ -175,7 +229,7 @@ A `.env` in the working directory is read on startup — copy `.env.example` and
 
 | Var | Used by | Default | Purpose |
 |---|---|---|---|
-| `ORA_API_URL` | audit, skill | `https://ora.ai` | Public API base (no auth) |
+| `ORA_API_URL` | audit, deep-journey, skill | `https://ora.ai` | Public API base (no auth) |
 | `ORA_PLATFORM_URL` | journey | `https://api.agentfront.sh` | Authenticated platform API base |
 | `ORA_API_KEY` | journey | — (required) | Secret key (`ora_sk_…`), exchanged for a short-lived bearer token |
 

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -52,14 +52,15 @@ check("--version matches package.json", () => {
 	}
 });
 
-check("--help exits 0 and lists both commands", () => {
+check("--help exits 0 and lists every command", () => {
 	const help = ax(["--help"]);
-	for (const command of ["audit", "journey"]) {
+	for (const command of ["audit", "deep-journey", "journey", "skill"]) {
 		if (!help.includes(command)) throw new Error(`help omits "${command}"`);
 	}
 });
 
 check("audit --help exits 0", () => ax(["audit", "--help"]));
+check("deep-journey --help exits 0", () => ax(["deep-journey", "--help"]));
 check("journey --help exits 0", () => ax(["journey", "--help"]));
 
 if (failures.length > 0) {

--- a/src/api/__fixtures__/deep-journey-detail.json
+++ b/src/api/__fixtures__/deep-journey-detail.json
@@ -1,0 +1,455 @@
+{
+	"id": "98cacf5c-4c08-4c21-97df-4f8e3e1f6f19",
+	"status": "succeeded",
+	"intent_id": "signup",
+	"domain": "captest-orank.com",
+	"agent": {
+		"harness": "claude-agent-sdk",
+		"model": "claude-haiku-4-5"
+	},
+	"started_at": "2026-08-14T01:51:54.882Z",
+	"finished_at": "2026-08-14T01:53:40.360Z",
+	"stream_url": "/api/journey/runs/98cacf5c-4c08-4c21-97df-4f8e3e1f6f19/stream",
+	"contractVersion": "1.9.0",
+	"verdict": "unsatisfied",
+	"step_count": 19,
+	"result": {
+		"run_id": "98cacf5c-4c08-4c21-97df-4f8e3e1f6f19",
+		"intent_id": "signup",
+		"domain": "captest-orank.com",
+		"harness": "claude-agent-sdk",
+		"model": "claude-haiku-4-5",
+		"started_at": "2026-08-14T01:51:54.882Z",
+		"finished_at": "2026-08-14T01:53:40.360Z",
+		"outcome": "failure",
+		"verdict": "unsatisfied",
+		"agent_response": "I'll help you access captest-orank.com and look for diagnostic tools or health-check endpoints. Let me start by fetching the main domain.",
+		"num_turns": 10,
+		"duration_ms": 38200,
+		"trajectory": {
+			"steps": [
+				{
+					"id": 0,
+					"type": "text",
+					"text": "I'll help you access stripe.com and look for diagnostic tools or health-check endpoints. Let me start by fetching the main domain."
+				},
+				{
+					"id": 1,
+					"turn": 1,
+					"type": "tool_call",
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "captest-orank.com/",
+					"url_host": "captest-orank.com",
+					"url_path": "/",
+					"source": "direct",
+					"anchor_relation": "exact",
+					"attribution": {
+						"kind": "prior_knowledge",
+						"artifact_kind": "homepage"
+					},
+					"status": 200,
+					"duration_ms": 5234,
+					"completed": true
+				},
+				{
+					"id": 2,
+					"turn": 2,
+					"type": "tool_call",
+					"parent_id": 1,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "status.captest-orank.com/",
+					"url_host": "status.captest-orank.com",
+					"url_path": "/",
+					"source": "follow",
+					"anchor_relation": "subdomain",
+					"attribution": {
+						"kind": "previous_artifact",
+						"artifact_kind": "homepage",
+						"referrer": {
+							"turn": 1,
+							"artifact_kind": "homepage",
+							"url_path": "/"
+						}
+					},
+					"status": 200,
+					"duration_ms": 2978,
+					"completed": true
+				},
+				{
+					"id": 3,
+					"turn": 2,
+					"type": "tool_call",
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "captest-orank.com/docs/health-check",
+					"url_host": "captest-orank.com",
+					"url_path": "/docs/health-check",
+					"source": "direct",
+					"anchor_relation": "exact",
+					"attribution": {
+						"kind": "prior_knowledge",
+						"artifact_kind": "docs_page",
+						"signal_id": "developer-portal"
+					},
+					"status": 301,
+					"duration_ms": 72,
+					"completed": true
+				},
+				{
+					"id": 4,
+					"turn": 3,
+					"type": "tool_call",
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "captest-orank.com/.well-known/health",
+					"url_host": "captest-orank.com",
+					"url_path": "/.well-known/health",
+					"source": "direct",
+					"anchor_relation": "exact",
+					"attribution": {
+						"kind": "prior_knowledge",
+						"artifact_kind": "well_known"
+					},
+					"status": 404,
+					"duration_ms": 344,
+					"completed": true
+				},
+				{
+					"id": 5,
+					"turn": 4,
+					"type": "tool_call",
+					"parent_id": 3,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "docs.captest-orank.com/health-check",
+					"url_host": "docs.captest-orank.com",
+					"url_path": "/health-check",
+					"source": "follow",
+					"anchor_relation": "subdomain",
+					"attribution": {
+						"kind": "previous_artifact",
+						"artifact_kind": "docs_page",
+						"signal_id": "developer-portal",
+						"referrer": {
+							"turn": 2,
+							"artifact_kind": "docs_page",
+							"url_path": "/docs/health-check"
+						}
+					},
+					"status": 404,
+					"duration_ms": 495,
+					"completed": true
+				},
+				{
+					"id": 6,
+					"turn": 5,
+					"type": "tool_call",
+					"action": "search",
+					"tool": "WebSearch",
+					"search_query": "captest-orank.com health check endpoint MCP server diagnostic tools",
+					"source": "direct",
+					"attribution": {
+						"kind": "web_search"
+					},
+					"duration_ms": 531,
+					"completed": true
+				},
+				{
+					"id": 7,
+					"turn": 5,
+					"type": "tool_call",
+					"parent_id": 3,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "captest-orank.com/docs",
+					"url_host": "captest-orank.com",
+					"url_path": "/docs",
+					"source": "follow",
+					"anchor_relation": "exact",
+					"attribution": {
+						"kind": "previous_artifact",
+						"artifact_kind": "docs_page",
+						"signal_id": "developer-portal",
+						"referrer": {
+							"turn": 2,
+							"artifact_kind": "docs_page",
+							"url_path": "/docs/health-check"
+						}
+					},
+					"status": 301,
+					"duration_ms": 74,
+					"completed": true
+				},
+				{
+					"id": 8,
+					"turn": 6,
+					"type": "tool_call",
+					"parent_id": 6,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "docs.captest-orank.com/mcp",
+					"url_host": "docs.captest-orank.com",
+					"url_path": "/mcp",
+					"source": "follow",
+					"anchor_relation": "subdomain",
+					"attribution": {
+						"kind": "web_search",
+						"artifact_kind": "docs_page",
+						"signal_id": "developer-portal"
+					},
+					"status": 200,
+					"duration_ms": 4636,
+					"completed": true
+				},
+				{
+					"id": 9,
+					"turn": 6,
+					"type": "tool_call",
+					"parent_id": 6,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "docs.captest-orank.com/health-alerts",
+					"url_host": "docs.captest-orank.com",
+					"url_path": "/health-alerts",
+					"source": "follow",
+					"anchor_relation": "subdomain",
+					"attribution": {
+						"kind": "web_search",
+						"artifact_kind": "docs_page",
+						"signal_id": "developer-portal"
+					},
+					"status": 200,
+					"duration_ms": 5716,
+					"completed": true
+				},
+				{
+					"id": 10,
+					"turn": 7,
+					"type": "tool_call",
+					"parent_id": 8,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "mcp.captest-orank.com/",
+					"url_host": "mcp.captest-orank.com",
+					"url_path": "/",
+					"source": "follow",
+					"anchor_relation": "subdomain",
+					"attribution": {
+						"kind": "previous_artifact",
+						"artifact_kind": "mcp_server",
+						"signal_id": "mcp-server",
+						"referrer": {
+							"turn": 6,
+							"artifact_kind": "mcp_endpoint_path",
+							"url_path": "/mcp"
+						}
+					},
+					"status": 401,
+					"duration_ms": 697,
+					"completed": true
+				},
+				{
+					"id": 11,
+					"turn": 7,
+					"type": "tool_call",
+					"action": "search",
+					"tool": "WebSearch",
+					"search_query": "Captest-orank MCP server health check endpoint localhost:3000",
+					"source": "direct",
+					"attribution": {
+						"kind": "web_search"
+					},
+					"duration_ms": 516,
+					"completed": true
+				},
+				{
+					"id": 12,
+					"turn": 8,
+					"type": "tool_call",
+					"parent_id": 11,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "mcpcat.io/guides/building-health-check-endpoint-mcp-server",
+					"url_host": "mcpcat.io",
+					"url_path": "/guides/building-health-check-endpoint-mcp-server",
+					"source": "follow",
+					"anchor_relation": "external",
+					"attribution": {
+						"kind": "web_search"
+					},
+					"status": 200,
+					"duration_ms": 6122,
+					"completed": true
+				},
+				{
+					"id": 13,
+					"turn": 8,
+					"type": "tool_call",
+					"parent_id": 9,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "docs.captest-orank.com/workbench/health",
+					"url_host": "docs.captest-orank.com",
+					"url_path": "/workbench/health",
+					"source": "follow",
+					"anchor_relation": "subdomain",
+					"attribution": {
+						"kind": "previous_artifact",
+						"artifact_kind": "docs_page",
+						"signal_id": "developer-portal",
+						"referrer": {
+							"turn": 6,
+							"artifact_kind": "docs_page",
+							"url_path": "/health-alerts"
+						}
+					},
+					"status": 200,
+					"duration_ms": 4148,
+					"completed": true
+				},
+				{
+					"id": 14,
+					"turn": 9,
+					"type": "tool_call",
+					"action": "search",
+					"tool": "WebSearch",
+					"search_query": "\"captest-orank mcp server\" \"health check\" OR \"health endpoint\" OR \"diagnostic\"",
+					"source": "direct",
+					"attribution": {
+						"kind": "web_search"
+					},
+					"duration_ms": 927,
+					"completed": true
+				},
+				{
+					"id": 15,
+					"turn": 9,
+					"type": "tool_call",
+					"parent_id": 7,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "docs.captest-orank.com/",
+					"url_host": "docs.captest-orank.com",
+					"url_path": "/",
+					"source": "follow",
+					"anchor_relation": "subdomain",
+					"attribution": {
+						"kind": "previous_artifact",
+						"artifact_kind": "homepage",
+						"referrer": {
+							"turn": 5,
+							"artifact_kind": "docs_page",
+							"url_path": "/docs"
+						}
+					},
+					"status": 200,
+					"duration_ms": 3297,
+					"completed": true
+				},
+				{
+					"id": 16,
+					"turn": 10,
+					"type": "tool_call",
+					"parent_id": 6,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "github.com/hideokamoto/stripe-testing-mcp-tools",
+					"url_host": "github.com",
+					"url_path": "/hideokamoto/stripe-testing-mcp-tools",
+					"source": "follow",
+					"anchor_relation": "external",
+					"attribution": {
+						"kind": "web_search"
+					},
+					"status": 200,
+					"duration_ms": 4261,
+					"completed": true
+				},
+				{
+					"id": 17,
+					"turn": 10,
+					"type": "tool_call",
+					"action": "search",
+					"tool": "WebSearch",
+					"search_query": "captest-orank api health check endpoint status",
+					"source": "direct",
+					"attribution": {
+						"kind": "web_search"
+					},
+					"duration_ms": 638,
+					"completed": true
+				},
+				{
+					"id": 18,
+					"turn": 11,
+					"type": "tool_call",
+					"parent_id": 17,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "api.captest-orank.com/healthcheck",
+					"url_host": "api.captest-orank.com",
+					"url_path": "/healthcheck",
+					"source": "follow",
+					"anchor_relation": "subdomain",
+					"attribution": {
+						"kind": "web_search",
+						"artifact_kind": "docs_page",
+						"signal_id": "developer-portal"
+					},
+					"status": 200,
+					"duration_ms": 2911,
+					"completed": true
+				},
+				{
+					"id": 19,
+					"turn": 11,
+					"type": "tool_call",
+					"parent_id": 6,
+					"action": "fetch",
+					"tool": "WebFetch",
+					"url": "status.captest-orank.com/reachability",
+					"url_host": "status.captest-orank.com",
+					"url_path": "/reachability",
+					"source": "follow",
+					"anchor_relation": "subdomain",
+					"attribution": {
+						"kind": "web_search"
+					},
+					"status": 200,
+					"duration_ms": 2486,
+					"completed": true
+				}
+			],
+			"action_sequence": "fetch,fetch+fetch,fetch,fetch,search+fetch,fetch+fetch,fetch+search,fetch+fetch,search+fetch,fetch+search,fetch+fetch",
+			"signals_observed": ["developer-portal"],
+			"friction_outcome": "timeout",
+			"status_profile": {
+				"count_2xx": 10,
+				"count_3xx": 2,
+				"count_4xx": 3,
+				"count_5xx": 0,
+				"first_error_step": 7,
+				"first_error_kind": "well_known"
+			},
+			"well_known_probes": [],
+			"path_origin_distribution": {
+				"prior_knowledge": 0.2,
+				"web_search": 0.4,
+				"previous_artifact": 0.4,
+				"other": 0
+			},
+			"link_following_rate": 0.4
+		},
+		"insight": {
+			"summary": "The agent probed widely but couldn't complete the task: alongside successful reads it hit several 4xx responses and redirects, and the resource it needed was gated or absent. It exhausted reasonable paths and ended without a confident answer.",
+			"key_observations": [
+				"A cluster of 4xx responses shows the agent tried endpoints that don't exist or require authentication - the target wasn't discoverable from a published hint.",
+				"Redirects (3xx) bounced the agent across canonical URLs, adding navigation cost without resolving the task.",
+				"The failure reflects a real agent-readiness gap for this task: the needed capability isn't exposed in a way a cold-start agent can reach."
+			],
+			"generated_at": "2026-05-30T07:26:26.282Z"
+		}
+	}
+}

--- a/src/api/audit.test.ts
+++ b/src/api/audit.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuditScanResult } from "../contract";
-import { resetContractWarning } from "../contract";
+import { BUILT_AGAINST, resetContractWarning } from "../contract";
 // Captured from a real `GET /api/scan/stream?domain=example.com&format=audit`
 // terminal event against contract 1.8.0 (2026-08-13). Real shape, not
 // hand-rolled - tests derive variations from it with explicit deltas.
@@ -89,7 +89,10 @@ describe("performAudit", () => {
 
 	it("warns on stderr once when the payload reports a newer contract", async () => {
 		const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-		const [major, minor] = FIXTURE.contractVersion.split(".").map(Number);
+		// Newer than the version this BUILD was generated against - the fixture's
+		// own contractVersion can lag BUILT_AGAINST after a regen, which is fine
+		// (older payloads never warn) but made it the wrong derivation base here.
+		const [major, minor] = BUILT_AGAINST.split(".").map(Number);
 		const newer = `${major}.${minor + 1}.0`;
 		vi.stubGlobal(
 			"fetch",

--- a/src/api/deep-journey.test.ts
+++ b/src/api/deep-journey.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import realDetail from "./__fixtures__/deep-journey-detail.json";
+import {
+	DeepJourneyApiError,
+	fetchJourneyAgents,
+	formatWait,
+	performDeepJourney,
+} from "./deep-journey";
+
+// Fixture provenance: deep-journey-detail.json is a real projected
+// GET /api/journey/runs/{id} response recorded from a dev run (contract
+// 1.9.0). Variations below are explicit deltas on it, never hand-rolled.
+
+const RUN_ID = (realDetail as { id: string }).id;
+
+// The journey stream is named SSE, the same framing the platform client
+// decodes (event: X + data: {json} + ": ping" heartbeats).
+const journeyStream = (events: Array<[string, unknown]>): Response =>
+	new Response(
+		events
+			.map(([name, data]) => `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`)
+			.join(": ping\n\n"),
+		{ status: 200, headers: { "content-type": "text/event-stream" } },
+	);
+
+const asJson = (body: unknown, status = 200, headers: Record<string, string> = {}): Response =>
+	new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json", ...headers },
+	});
+
+const RECORD = {
+	id: RUN_ID,
+	status: "running",
+	intent_id: "pricing",
+	domain: "vercel.com",
+	agent: { harness: "claude-agent-sdk", model: "claude-haiku-4-5" },
+	started_at: "2026-08-14T00:00:00.000Z",
+	stream_url: `/api/journey/runs/${RUN_ID}/stream`,
+	contractVersion: "1.9.0",
+};
+
+function journeyMock(config: { trigger?: Response; stream?: Response; details?: unknown[] }) {
+	let detailCalls = 0;
+	return vi.fn(async (url: string | URL, init?: { method?: string }) => {
+		const at = String(url);
+		if (at.endsWith("/api/journey/runs") && init?.method === "POST") {
+			return (
+				config.trigger ??
+				asJson(RECORD, 201, {
+					"x-ratelimit-limit": "5",
+					"x-ratelimit-remaining": "4",
+					"x-ratelimit-reset": "1770000000",
+				})
+			);
+		}
+		if (at.includes("/stream") && config.stream) return config.stream;
+		if (at.endsWith("/api/journey/agents")) {
+			return asJson({
+				agents: [
+					{
+						id: "cas-haiku",
+						label: "Claude Code",
+						variant: "Haiku 4.5",
+						harness: "claude-agent-sdk",
+						model: "claude-haiku-4-5",
+					},
+				],
+				defaultId: "cas-haiku",
+			});
+		}
+		if (at.includes("/api/journey/runs/")) {
+			const details = config.details ?? [realDetail];
+			const body = details[Math.min(detailCalls, details.length - 1)];
+			detailCalls += 1;
+			return asJson(body);
+		}
+		return asJson({});
+	});
+}
+
+const OPTIONS = {
+	intentId: "pricing",
+	harness: "claude-agent-sdk",
+	model: "claude-haiku-4-5",
+	baseUrl: "https://journey.test",
+};
+
+describe("performDeepJourney", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	it("streams to the result and returns the terminal detail + allowance", async () => {
+		vi.stubGlobal(
+			"fetch",
+			journeyMock({
+				stream: journeyStream([
+					["run_id", { run_id: RUN_ID }],
+					[
+						"trajectory",
+						{ steps: [{ id: 0, type: "tool_call", action: "fetch", completed: false }] },
+					],
+					["processing", { message: "generating insights" }],
+					["result", (realDetail as { result: unknown }).result],
+				]),
+			}),
+		);
+
+		const lines: string[] = [];
+		const outcome = await performDeepJourney("vercel.com", {
+			...OPTIONS,
+			progress: (line) => lines.push(line),
+		});
+
+		expect(outcome.cached).toBe(false);
+		expect(outcome.allowance).toEqual({ limit: 5, remaining: 4, resetAtMs: 1770000000000 });
+		expect(outcome.detail.status).toBe("succeeded");
+		expect(outcome.detail.step_count).toBe(19);
+		expect(outcome.detail.verdict).toBe("unsatisfied");
+		expect(lines.some((line) => line.includes("step 1"))).toBe(true);
+	});
+
+	it("treats a capped 200 as a cached outcome, not an error", async () => {
+		vi.stubGlobal(
+			"fetch",
+			journeyMock({
+				trigger: asJson(
+					{
+						...RECORD,
+						status: "succeeded",
+						rate_limited: true,
+						limit: { max: 5, window_ms: 86_400_000 },
+						retry_after_ms: 3_600_000,
+					},
+					200,
+					{ "x-ratelimit-limit": "5", "x-ratelimit-remaining": "0" },
+				),
+			}),
+		);
+
+		const outcome = await performDeepJourney("vercel.com", OPTIONS);
+		expect(outcome.cached).toBe(true);
+		expect(outcome.retryAfterMs).toBe(3_600_000);
+		expect(outcome.detail.status).toBe("succeeded");
+	});
+
+	it("resolves a stream error frame as the failed detail (exit-code parity with --no-stream)", async () => {
+		vi.stubGlobal(
+			"fetch",
+			journeyMock({
+				stream: journeyStream([
+					["run_id", { run_id: RUN_ID }],
+					["error", { message: "engine stream interrupted" }],
+				]),
+				details: [{ ...(realDetail as object), status: "failed", result: undefined }],
+			}),
+		);
+
+		const outcome = await performDeepJourney("vercel.com", OPTIONS);
+		expect(outcome.detail.status).toBe("failed");
+		expect(outcome.engineError).toBe("engine stream interrupted");
+	});
+
+	it("maps a durable 429 to an actionable error with the retry hint", async () => {
+		vi.stubGlobal(
+			"fetch",
+			journeyMock({
+				trigger: asJson({ error: "Too many requests", retry_after_ms: 86_400_000 }, 429, {
+					"retry-after": "86400",
+				}),
+			}),
+		);
+
+		await expect(performDeepJourney("vercel.com", OPTIONS)).rejects.toThrow(DeepJourneyApiError);
+	});
+
+	it("refuses to treat a never-settling run as terminal (truncated stream)", async () => {
+		// The stream closes cleanly with no result/error frame (e.g. the serving
+		// function's 800s ceiling) and the detail never leaves "running".
+		vi.useFakeTimers();
+		try {
+			vi.stubGlobal(
+				"fetch",
+				journeyMock({
+					stream: journeyStream([
+						["run_id", { run_id: RUN_ID }],
+						["trajectory", { steps: [{ id: 0, type: "tool_call", action: "fetch" }] }],
+					]),
+					details: [{ ...(realDetail as object), status: "running", result: undefined }],
+				}),
+			);
+
+			// Capture the settled state up front - the rejection lands only after
+			// the fake clock advances past the detail-settle retries.
+			const settled = performDeepJourney("vercel.com", OPTIONS).then(
+				() => "resolved",
+				(cause) => cause,
+			);
+			await vi.advanceTimersByTimeAsync(10_000);
+			const error = await settled;
+			expect(error).toBeInstanceOf(DeepJourneyApiError);
+			expect(String(error)).toMatch(/still executing/);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("polls to the terminal detail with --no-stream", async () => {
+		vi.stubGlobal(
+			"fetch",
+			journeyMock({
+				details: [{ ...(realDetail as object), status: "running", result: undefined }, realDetail],
+			}),
+		);
+
+		const outcome = await performDeepJourney("vercel.com", {
+			...OPTIONS,
+			noStream: true,
+			pollEveryMs: 1,
+		});
+		expect(outcome.detail.status).toBe("succeeded");
+		expect(outcome.detail.result).toBeDefined();
+	});
+});
+
+describe("fetchJourneyAgents", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	it("returns the public roster", async () => {
+		vi.stubGlobal("fetch", journeyMock({}));
+		const { agents, defaultId } = await fetchJourneyAgents("https://journey.test");
+		expect(defaultId).toBe("cas-haiku");
+		expect(agents[0]?.harness).toBe("claude-agent-sdk");
+	});
+});
+
+describe("formatWait", () => {
+	it("rounds up to the readable unit", () => {
+		expect(formatWait(86_400_000)).toBe("24h");
+		expect(formatWait(90_000)).toBe("2m");
+		expect(formatWait(4_000)).toBe("4s");
+		expect(formatWait(0)).toBe("soon");
+	});
+});

--- a/src/api/deep-journey.ts
+++ b/src/api/deep-journey.ts
@@ -1,0 +1,403 @@
+import type {
+	JourneyRun,
+	JourneyRunDetail,
+	JourneyRunResult,
+	JourneyTrajectoryStep,
+} from "../contract";
+import { warnOnNewerContract } from "../contract";
+import { decodeEventBlock } from "./platform";
+import { errorBodyText, pause, watchdog } from "./shared";
+
+// Client for ora's public deep-journey API (/api/journey/*): a real AI agent
+// attempts a curated task against a domain while ora records the trajectory.
+// Unauthenticated by design (same posture as audit.ts) - the public surface is
+// rate-limited per target and per caller, not keyed.
+//
+// Thin client: every field (verdict, step_count, insight, trajectory) comes
+// from the versioned journey contract as-is; nothing here re-derives judgement.
+// The stream is NAMED SSE (event: run_id / trajectory / processing / result /
+// error), the same framing the platform client decodes - decodeEventBlock is
+// shared from there.
+
+const PUBLIC_BASE = "https://ora.ai";
+// A live engine run can take several minutes end to end, but frames arrive at
+// least every few seconds while it works; this bounds SILENCE, not the run.
+const STREAM_IDLE_MS = 120_000;
+const POLL_EVERY_MS = 5_000;
+const POLL_LIMIT = 180; // ≈15min of --no-stream patience, matching the server's run ceiling
+
+/** Any failure to obtain a run from ora: network, HTTP, rate limit, stream error. */
+export class DeepJourneyApiError extends Error {}
+
+export interface JourneyIntentOption {
+	id: string;
+	label: string;
+	hint: string;
+	template: string;
+}
+
+export interface JourneyAgentOption {
+	id: string;
+	label: string;
+	variant: string;
+	harness: string;
+	model: string;
+	blurb?: string;
+}
+
+/** The per-target allowance the POST response advertises via X-RateLimit-*. */
+export interface RunAllowance {
+	limit?: number;
+	remaining?: number;
+	/** Unix ms when the next per-target slot frees; absent when unknown. */
+	resetAtMs?: number;
+}
+
+export interface DeepJourneyOptions {
+	/** Curated intent id; the server default when omitted. */
+	intentId?: string;
+	harness: string;
+	model: string;
+	/** Receives one-line progress updates while the run streams/polls. */
+	progress?: (line: string) => void;
+	/** Base URL override; otherwise $ORA_API_URL, otherwise https://ora.ai. */
+	baseUrl?: string;
+	/** Abort when the stream is silent for this long (default 120s). */
+	idleMs?: number;
+	/** Skip the SSE and poll GET /api/journey/runs/{id} instead. */
+	noStream?: boolean;
+	pollEveryMs?: number;
+	pollLimit?: number;
+}
+
+export interface DeepJourneyOutcome {
+	/** The projected run record from the trigger (or the cached latest run). */
+	record: JourneyRun;
+	/** True when the per-target cap answered with the stored latest run. */
+	cached: boolean;
+	/** Milliseconds until a per-target slot frees, on a cached answer. */
+	retryAfterMs?: number;
+	allowance: RunAllowance;
+	/** Terminal detail: status, verdict, step_count, and result once succeeded. */
+	detail: JourneyRunDetail;
+	/** The stream's terminal error message, when the run failed mid-stream. */
+	engineError?: string;
+}
+
+function apiBase(baseUrl?: string): string {
+	return (baseUrl ?? process.env.ORA_API_URL ?? PUBLIC_BASE).replace(/\/+$/, "");
+}
+
+async function getJson<T>(url: string): Promise<T> {
+	let res: Response;
+	try {
+		res = await fetch(url, {
+			headers: { accept: "application/json" },
+			signal: AbortSignal.timeout(15_000),
+		});
+	} catch (cause) {
+		const detail = cause instanceof Error ? cause.message : String(cause);
+		throw new DeepJourneyApiError(`ora request failed: ${detail}`);
+	}
+	if (!res.ok) throw new DeepJourneyApiError(`ora request failed: ${await errorBodyText(res)}`);
+	return (await res.json()) as T;
+}
+
+/** The curated intents a public run can execute. */
+export function fetchJourneyIntents(
+	baseUrl?: string,
+): Promise<{ intents: JourneyIntentOption[]; defaultId: string }> {
+	return getJson(`${apiBase(baseUrl)}/api/journey/intents`);
+}
+
+/** The agents an anonymous run request accepts. */
+export function fetchJourneyAgents(
+	baseUrl?: string,
+): Promise<{ agents: JourneyAgentOption[]; defaultId: string }> {
+	return getJson(`${apiBase(baseUrl)}/api/journey/agents`);
+}
+
+function allowanceFrom(res: Response): RunAllowance {
+	const num = (name: string): number | undefined => {
+		const raw = res.headers.get(name);
+		if (raw === null) return undefined;
+		const parsed = Number.parseInt(raw, 10);
+		return Number.isFinite(parsed) ? parsed : undefined;
+	};
+	const resetSeconds = num("x-ratelimit-reset");
+	return {
+		limit: num("x-ratelimit-limit"),
+		remaining: num("x-ratelimit-remaining"),
+		resetAtMs: resetSeconds !== undefined ? resetSeconds * 1000 : undefined,
+	};
+}
+
+interface TriggeredRun {
+	record: JourneyRun & { rate_limited?: boolean; retry_after_ms?: number };
+	cached: boolean;
+	allowance: RunAllowance;
+}
+
+async function triggerRun(
+	base: string,
+	target: string,
+	options: DeepJourneyOptions,
+): Promise<TriggeredRun> {
+	const body: Record<string, unknown> = {
+		intent: {
+			...(options.intentId ? { intent_id: options.intentId } : {}),
+			domain: target,
+		},
+		harness: options.harness,
+		model: options.model,
+	};
+
+	let res: Response;
+	try {
+		res = await fetch(`${base}/api/journey/runs`, {
+			method: "POST",
+			headers: { "content-type": "application/json", accept: "application/json" },
+			body: JSON.stringify(body),
+			signal: AbortSignal.timeout(30_000),
+		});
+	} catch (cause) {
+		const detail = cause instanceof Error ? cause.message : String(cause);
+		throw new DeepJourneyApiError(`ora journey request failed: ${detail}`);
+	}
+
+	if (res.status === 429) {
+		const wait = res.headers.get("retry-after");
+		throw new DeepJourneyApiError(
+			`ora journey caller limit exceeded${wait ? ` — retry after ${formatWait(Number(wait) * 1000)}` : ""} (burst: 20/min/IP; daily: 10 runs per 24h per IP)`,
+		);
+	}
+	if (res.status === 503) {
+		throw new DeepJourneyApiError("ora's run engine is unavailable right now — try again shortly");
+	}
+	if (!res.ok) {
+		throw new DeepJourneyApiError(`ora journey request failed: ${await errorBodyText(res)}`);
+	}
+
+	const record = (await res.json()) as TriggeredRun["record"];
+	warnOnNewerContract(record.contractVersion);
+	return { record, cached: record.rate_limited === true, allowance: allowanceFrom(res) };
+}
+
+export function formatWait(ms: number): string {
+	if (!Number.isFinite(ms) || ms <= 0) return "soon";
+	const hours = ms / 3_600_000;
+	if (hours >= 1) return `${Math.ceil(hours)}h`;
+	const minutes = ms / 60_000;
+	if (minutes >= 1) return `${Math.ceil(minutes)}m`;
+	return `${Math.ceil(ms / 1000)}s`;
+}
+
+// --- Live stream ---
+
+// Present-tense caption for the newest step in a trajectory frame.
+function activityLabel(step: JourneyTrajectoryStep | undefined): string {
+	if (!step) return "starting…";
+	if (step.type === "text") return "thinking…";
+	if (step.action === "search") {
+		return step.search_query ? `searching “${clip(step.search_query, 40)}”` : "searching…";
+	}
+	const where = step.label ?? `${step.url_host ?? ""}${step.url_path ?? ""}`;
+	const doing = step.completed === false ? "fetching" : "fetched";
+	return where ? `${doing} ${clip(where, 48)}` : `${doing}…`;
+}
+
+function clip(text: string, max: number): string {
+	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+interface StreamedJourney {
+	result?: JourneyRunResult;
+	errorMessage?: string;
+}
+
+async function followJourneyStream(
+	base: string,
+	streamPath: string,
+	options: DeepJourneyOptions,
+): Promise<StreamedJourney> {
+	const target = streamPath.startsWith("http") ? streamPath : `${base}${streamPath}`;
+	const idleMs = options.idleMs ?? STREAM_IDLE_MS;
+	const dog = watchdog(idleMs);
+	const timeoutError = () =>
+		new DeepJourneyApiError(
+			`ora journey stream timed out — no frames for ${Math.round(idleMs / 1000)}s`,
+		);
+
+	let res: Response;
+	try {
+		res = await fetch(target, {
+			headers: { accept: "text/event-stream" },
+			signal: dog.signal,
+		});
+	} catch (cause) {
+		dog.disarm();
+		if (dog.tripped()) throw timeoutError();
+		const detail = cause instanceof Error ? cause.message : String(cause);
+		throw new DeepJourneyApiError(`ora journey stream failed: ${detail}`);
+	}
+	if (!res.ok || !res.body) {
+		dog.disarm();
+		throw new DeepJourneyApiError(`ora journey stream failed: ${await errorBodyText(res)}`);
+	}
+
+	const utf8 = new TextDecoder();
+	const collected: StreamedJourney = {};
+	let pending = "";
+
+	try {
+		streaming: for await (const chunk of res.body) {
+			dog.poke();
+			pending = `${pending}${utf8.decode(chunk as Uint8Array, { stream: true })}`.replace(
+				/\r\n?/g,
+				"\n",
+			);
+			let cut = pending.indexOf("\n\n");
+			while (cut !== -1) {
+				const decoded = decodeEventBlock(pending.slice(0, cut));
+				pending = pending.slice(cut + 2);
+				cut = pending.indexOf("\n\n");
+				if (!decoded) continue;
+				let payload: Record<string, unknown>;
+				try {
+					payload = JSON.parse(decoded.data);
+				} catch {
+					continue;
+				}
+				if (decoded.event === "trajectory") {
+					const steps = (payload.steps ?? []) as JourneyTrajectoryStep[];
+					const active = steps.filter((s) => s.type === "tool_call").at(-1);
+					options.progress?.(`step ${steps.length} · ${activityLabel(active ?? steps.at(-1))}`);
+				} else if (decoded.event === "processing") {
+					options.progress?.(
+						typeof payload.message === "string" ? payload.message : "generating insights…",
+					);
+				} else if (decoded.event === "result") {
+					collected.result = payload as unknown as JourneyRunResult;
+					break streaming;
+				} else if (decoded.event === "error") {
+					collected.errorMessage =
+						typeof payload.message === "string" ? payload.message : "unknown engine error";
+					break streaming;
+				}
+			}
+		}
+	} catch (cause) {
+		if (dog.tripped()) throw timeoutError();
+		if (cause instanceof DeepJourneyApiError) throw cause;
+		const detail = cause instanceof Error ? cause.message : String(cause);
+		throw new DeepJourneyApiError(`ora journey stream error: ${detail}`);
+	} finally {
+		dog.disarm();
+		res.body.cancel().catch(() => {});
+	}
+
+	return collected;
+}
+
+/** Non-streaming run detail (verdict, step_count, result once succeeded). */
+export function fetchRunDetail(base: string, runId: string): Promise<JourneyRunDetail> {
+	return getJson<JourneyRunDetail>(`${base}/api/journey/runs/${encodeURIComponent(runId)}`);
+}
+
+async function awaitByPolling(
+	base: string,
+	runId: string,
+	options: DeepJourneyOptions,
+): Promise<JourneyRunDetail> {
+	const every = options.pollEveryMs ?? POLL_EVERY_MS;
+	const limit = options.pollLimit ?? POLL_LIMIT;
+	let latest = await fetchRunDetail(base, runId);
+	for (let round = 0; round < limit && latest.status === "running"; round++) {
+		options.progress?.("agent working… (polling)");
+		await pause(every);
+		try {
+			latest = await fetchRunDetail(base, runId);
+		} catch {
+			// transient hiccup — keep polling until the round budget is spent
+		}
+	}
+	return latest;
+}
+
+/**
+ * Run a deep journey against `target` and resolve with the terminal detail.
+ * Streams the trajectory by default (progress lines via `options.progress`);
+ * with `noStream`, polls the record instead. A per-target-capped trigger is
+ * NOT an error: ora answers with the most recent stored run for that target,
+ * and the outcome carries `cached: true` plus `retryAfterMs`.
+ */
+export async function performDeepJourney(
+	target: string,
+	options: DeepJourneyOptions,
+): Promise<DeepJourneyOutcome> {
+	const base = apiBase(options.baseUrl);
+
+	const triggered = await triggerRun(base, target, options);
+	const { record } = triggered;
+
+	if (triggered.cached) {
+		options.progress?.("target at its 24h cap — fetching the most recent stored run");
+	}
+
+	// A cached record can still be "running" (the latest run is mid-flight);
+	// live streaming attaches to it the same way a fresh run does.
+	let engineError: string | undefined;
+	if (!options.noStream && record.status === "running") {
+		const streamed = await followJourneyStream(base, record.stream_url, options);
+		// A terminal `error` frame means the run failed - NOT a client failure.
+		// Fall through to the detail so a failed run resolves the same way it
+		// does under --no-stream (status "failed" -> the caller's run-failed
+		// path), keeping exit codes consistent across both modes.
+		engineError = streamed.errorMessage;
+	} else if (options.noStream && record.status === "running") {
+		await awaitByPolling(base, record.id, options);
+	}
+
+	// The detail is the terminal source of truth: verdict + step_count +
+	// (once succeeded) the full result. One extra GET, always fresh.
+	const detail = await awaitDetailSettled(base, record.id, options);
+	// A run can outlive the stream (the serving function's 800s ceiling, or any
+	// clean connection close before the terminal frame) and the poll budget. A
+	// still-running detail has no verdict to render - never return it as terminal.
+	if (detail.status === "running") {
+		// With an engine error in hand the run IS over; only the row lagged.
+		if (engineError) {
+			throw new DeepJourneyApiError(`ora journey run failed: ${engineError}`);
+		}
+		throw new DeepJourneyApiError(
+			`run ${record.id} is still executing — the ${
+				options.noStream ? "poll budget ran out" : "stream ended"
+			} before a terminal result. Check ${base}/api/journey/runs/${record.id} shortly`,
+		);
+	}
+	warnOnNewerContract(detail.contractVersion);
+	return {
+		record,
+		cached: triggered.cached,
+		retryAfterMs: triggered.record.retry_after_ms,
+		allowance: triggered.allowance,
+		detail,
+		engineError,
+	};
+}
+
+// The stream's terminal frame and the row persist race by a beat; a couple of
+// short retries lets the detail settle without a user-visible pause.
+async function awaitDetailSettled(
+	base: string,
+	runId: string,
+	options: DeepJourneyOptions,
+): Promise<JourneyRunDetail> {
+	let detail = await fetchRunDetail(base, runId);
+	for (let round = 0; round < 3 && detail.status === "running"; round++) {
+		options.progress?.("finalizing…");
+		await pause(1_500);
+		detail = await fetchRunDetail(base, runId);
+	}
+	return detail;
+}

--- a/src/commands/deep-journey.ts
+++ b/src/commands/deep-journey.ts
@@ -1,0 +1,175 @@
+import pc from "picocolors";
+import {
+	DeepJourneyApiError,
+	type DeepJourneyOutcome,
+	fetchJourneyAgents,
+	fetchJourneyIntents,
+	formatWait,
+	type JourneyAgentOption,
+	performDeepJourney,
+} from "../api/deep-journey";
+import { spinner } from "../ui/spinner";
+
+// `ax deep-journey <url>`: run a real agent at a site through ora's PUBLIC
+// journey API (no key, no workspace - unlike `ax journey`, which drives the
+// authenticated platform). Thin client: verdict, step_count, and insight are
+// rendered exactly as the contract delivers them; nothing is re-judged here.
+
+export const EXIT = { OK: 0, RUN_FAILED: 1, USAGE: 2, API: 3 } as const;
+
+// The documented public caps, shown up front so a CI author can budget runs
+// before spending one. The live remaining allowance comes from the response
+// headers after the trigger.
+const CAPS_LINE = "public caps: 5 runs/24h per target · 10 runs/24h per IP";
+
+export interface DeepJourneyCommandInput {
+	url: string;
+	intent?: string;
+	agent?: string;
+	json: boolean;
+	noStream: boolean;
+}
+
+function fail(message: string): typeof EXIT.API {
+	console.error(pc.red(`ax deep-journey: ${message}`));
+	return EXIT.API;
+}
+
+function verdictLine(verdict: string | undefined, status: string): string {
+	if (status === "failed") return pc.red("✗ run failed");
+	switch (verdict) {
+		case "satisfied":
+			return pc.green("✓ task satisfied");
+		case "partial":
+			return pc.yellow("◐ partially satisfied");
+		case "unsatisfied":
+			return pc.red("✗ task not satisfied");
+		default:
+			return pc.dim("· not gradable");
+	}
+}
+
+function agentLine(agent: JourneyAgentOption): string {
+	return `${agent.label} · ${agent.variant}`;
+}
+
+function renderOutcome(outcome: DeepJourneyOutcome, url: string): string[] {
+	const { detail } = outcome;
+	const lines: string[] = [""];
+
+	lines.push(`${verdictLine(detail.verdict, detail.status)}  ${pc.dim(detail.domain ?? url)}`);
+
+	const chips: string[] = [];
+	if (detail.step_count != null) chips.push(`${detail.step_count} steps`);
+	const result = detail.result;
+	if (result?.num_turns != null) chips.push(`${result.num_turns} turns`);
+	if (result?.duration_ms != null) chips.push(`${(result.duration_ms / 1000).toFixed(1)}s`);
+	if (chips.length) lines.push(pc.dim(chips.join(" · ")));
+
+	if (result?.insight?.summary) {
+		lines.push("", result.insight.summary);
+	}
+	for (const observation of result?.insight?.key_observations ?? []) {
+		lines.push(pc.dim(`  - ${observation}`));
+	}
+
+	if (detail.status === "failed") {
+		lines.push(
+			"",
+			pc.dim(
+				outcome.engineError
+					? `Engine error: ${outcome.engineError} — re-running is free to try.`
+					: "The run ended in an engine error; re-running is free to try.",
+			),
+		);
+	}
+
+	lines.push("", pc.dim(`For the 4-layer readiness audit, run: ax audit ${url}`));
+	return lines;
+}
+
+export async function deepJourneyCommand(input: DeepJourneyCommandInput): Promise<number> {
+	const target = input.url.trim();
+	if (!target) {
+		console.error("ax deep-journey: a target URL or domain is required");
+		return EXIT.USAGE;
+	}
+
+	const interactive = !input.json && process.stderr.isTTY;
+
+	// Resolve the intent and agent against the live rosters (both static,
+	// cached routes) so a typo fails with the menu instead of a bare 400.
+	let intentId = input.intent;
+	let agent: JourneyAgentOption;
+	try {
+		const [intents, agents] = await Promise.all([fetchJourneyIntents(), fetchJourneyAgents()]);
+		if (intentId === undefined) {
+			intentId = intents.defaultId;
+		} else if (!intents.intents.some((option) => option.id === intentId)) {
+			console.error(
+				`ax deep-journey: unknown intent "${intentId}". Available intents:\n${intents.intents
+					.map((option) => `  ${option.id.padEnd(12)} ${option.hint}`)
+					.join("\n")}`,
+			);
+			return EXIT.USAGE;
+		}
+		const wantedAgent = input.agent ?? agents.defaultId;
+		const found = agents.agents.find((option) => option.id === wantedAgent);
+		if (!found) {
+			console.error(
+				`ax deep-journey: unknown agent "${wantedAgent}". Available agents:\n${agents.agents
+					.map((option) => `  ${option.id.padEnd(12)} ${agentLine(option)}`)
+					.join("\n")}`,
+			);
+			return EXIT.USAGE;
+		}
+		agent = found;
+	} catch (error) {
+		return fail(error instanceof Error ? error.message : String(error));
+	}
+
+	if (!input.json) {
+		console.error(pc.dim(CAPS_LINE));
+	}
+	if (interactive) spinner.start(`Sending ${agentLine(agent)} to ${target} (${intentId})`);
+
+	let outcome: DeepJourneyOutcome;
+	try {
+		outcome = await performDeepJourney(target, {
+			intentId,
+			harness: agent.harness,
+			model: agent.model,
+			noStream: input.noStream,
+			progress: interactive ? (line) => spinner.update(line) : undefined,
+		});
+	} catch (error) {
+		if (interactive) spinner.stop();
+		if (error instanceof DeepJourneyApiError) return fail(error.message);
+		return fail(error instanceof Error ? error.message : String(error));
+	}
+	if (interactive) spinner.stop();
+
+	if (input.json) {
+		console.log(JSON.stringify(outcome.detail, null, 2));
+		return outcome.detail.status === "failed" ? EXIT.RUN_FAILED : EXIT.OK;
+	}
+
+	if (outcome.cached) {
+		console.error(
+			pc.yellow(
+				`This target hit its 24h cap — showing the most recent stored run${
+					outcome.retryAfterMs ? ` (fresh run in ${formatWait(outcome.retryAfterMs)})` : ""
+				}.`,
+			),
+		);
+	} else if (outcome.allowance.remaining !== undefined && outcome.allowance.limit !== undefined) {
+		console.error(
+			pc.dim(
+				`allowance: ${outcome.allowance.remaining} of ${outcome.allowance.limit} target runs left in the 24h window`,
+			),
+		);
+	}
+
+	for (const line of renderOutcome(outcome, target)) console.log(line);
+	return outcome.detail.status === "failed" ? EXIT.RUN_FAILED : EXIT.OK;
+}

--- a/src/contract/index.ts
+++ b/src/contract/index.ts
@@ -11,6 +11,12 @@ export type AuditCheck = components["schemas"]["AuditCheck"];
 export type AuditLayer = components["schemas"]["AuditLayer"];
 export type AuditTopFix = AuditScanResult["topFixes"][number];
 
+export type JourneyRun = components["schemas"]["JourneyRun"];
+export type JourneyCappedRun = components["schemas"]["JourneyCappedRun"];
+export type JourneyRunDetail = components["schemas"]["JourneyRunDetail"];
+export type JourneyRunResult = components["schemas"]["JourneyRunResult"];
+export type JourneyTrajectoryStep = components["schemas"]["JourneyTrajectoryStep"];
+
 export { BUILT_AGAINST };
 
 function minor(version: string): [number, number] {

--- a/src/contract/types.gen.ts
+++ b/src/contract/types.gen.ts
@@ -119,6 +119,41 @@ export interface paths {
      */
     get: operations["ardGetJwks"];
   };
+  "/api/journey/runs": {
+    /**
+     * Run an agent journey against a domain
+     * @description Triggers a real agent run: an AI agent (harness + model) attempts a curated task (an intent) against the given domain, and ora records the trajectory and derives insights. Two-step flow: this endpoint returns fast with a run record whose `stream_url` serves the live trajectory as Server-Sent Events; poll GET /api/journey/runs/{id} instead if you do not want the stream. Only curated intents run publicly (see GET /api/journey/intents) - the server derives the actual agent prompt from the intent id, so no free-text prompt can reach the engine. Only publicly runnable agents are accepted (see GET /api/journey/agents). Unknown body fields are rejected (strict schema). Rate limited three ways: a 20-per-minute burst cap per IP; a per-target cap of 5 runs per rolling 24h per (domain, intent, harness, model) - when a target is over the cap the response is HTTP 200 with the most recent stored run for that target (`rate_limited: true`) plus Retry-After, the freshness analog: a denied trigger still returns the newest result and consumes nothing; and a durable per-caller cap of 10 runs per rolling 24h per IP - exceeded, that one is a real 429 with `retry_after_ms` (there is no cached result to serve for a caller). Successful and capped responses carry X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset headers for the per-target window. Note: journey insights use the 5-layer journey taxonomy (discovery, identity, access, payments, experience), deliberately distinct from the 4 scoring layers of the audit report (POST /api/scan) - never map between the two.
+     */
+    post: operations["createJourneyRun"];
+  };
+  "/api/journey/runs/{id}": {
+    /**
+     * Get a journey run record (non-streaming)
+     * @description Returns the run record by id. While the run executes, `status` is 'running' - open the stream or poll. Once finished and persisted, `status` is 'succeeded' and the body carries `verdict`, `step_count` (billable steps - the same counter run pricing uses), and the full `result` (trajectory + insight + signals). `status` 'failed' is terminal with no result. `result` is present iff status is 'succeeded'.
+     */
+    get: operations["getJourneyRun"];
+  };
+  "/api/journey/runs/{id}/stream": {
+    /**
+     * Stream a journey run's trajectory as Server-Sent Events
+     * @description The live trajectory SSE for a run created by POST /api/journey/runs. Event names (stable): `run_id` ({ run_id }), then progressive `trajectory` frames (cumulative snapshots, each a { steps, ... } object of JourneyTrajectoryStep items), optionally `processing` ({ message }) while insights generate, and finally exactly one of `result` (a JourneyRunResult) or `error` ({ message }). Reopening the stream of a finished run replays the stored result instead of re-executing the agent (pass ?replay=1 for paced frames, plus &quick=1 to skip the startup delay); a plain reopen renders the finished journey in one frame. Long-lived: a live run can hold the connection for many minutes (function ceiling 800s). Rate limited 20 per minute per IP.
+     */
+    get: operations["streamJourneyRun"];
+  };
+  "/api/journey/intents": {
+    /**
+     * List the curated journey intents
+     * @description The curated tasks a public journey run can execute. Each entry carries the stable `id` (what POST /api/journey/runs takes), a short `label`, a one-line `hint`, and the user-facing `template` phrasing. Cached statically.
+     */
+    get: operations["listJourneyIntents"];
+  };
+  "/api/journey/agents": {
+    /**
+     * List the publicly runnable journey agents
+     * @description The agents an anonymous POST /api/journey/runs accepts - every listed (harness, model) pair is publicly runnable. Entries carry display metadata (label, variant, brand, blurb) plus the wire fields `harness` and `model`. Cached statically.
+     */
+    get: operations["listJourneyAgents"];
+  };
   "/api/feedback/{domain}": {
     /**
      * Get agent feedback for a product
@@ -272,7 +307,7 @@ export interface components {
        * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.8.0";
+      contractVersion: "1.9.0";
       /**
        * @description Present only when this body is a stored result served by the freshness gate instead of a fresh scan. Absent on a live scan.
        * @enum {boolean}
@@ -384,7 +419,7 @@ export interface components {
        * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.8.0";
+      contractVersion: "1.9.0";
       /** @description Wall-clock duration of the scan that produced this stored result */
       durationMs: number | null;
       /**
@@ -415,6 +450,621 @@ export interface components {
       competitors?: {
         [key: string]: unknown;
       } | null;
+    };
+    JourneyRun: {
+      /** @description Run id - the handle for GET /api/journey/runs/{id} and the stream */
+      id: string;
+      /**
+       * @description Lifecycle status. failed is terminal; a failed run has no result.
+       * @enum {string}
+       */
+      status: "running" | "succeeded" | "failed";
+      /** @description Curated intent id (see GET /api/journey/intents) */
+      intent_id?: string;
+      /** @description Target domain */
+      domain?: string;
+      /** @description The agent configuration that ran (or is running) */
+      agent: {
+        /** @description Agent harness wire name */
+        harness: string;
+        /** @description Model the harness drives */
+        model: string;
+      };
+      started_at: string;
+      finished_at?: string;
+      /** @description SSE stream for this run: run_id -> trajectory -> processing -> result | error */
+      stream_url: string;
+      /**
+       * @description Canonical success verdict, present once the run finished
+       * @enum {string}
+       */
+      verdict?: "satisfied" | "partial" | "unsatisfied" | "not_gradable";
+      /** @description Billable steps the run took (tool calls, excluding narration and filesystem ops), present once the run finished. This is the same counter run pricing uses. */
+      step_count?: number;
+      /** @description Journey/audit contract version (shared SemVer; see docs) */
+      contractVersion: string;
+    };
+    JourneyCappedRun: {
+      /** @description Run id - the handle for GET /api/journey/runs/{id} and the stream */
+      id: string;
+      /**
+       * @description Lifecycle status. failed is terminal; a failed run has no result.
+       * @enum {string}
+       */
+      status: "running" | "succeeded" | "failed";
+      /** @description Curated intent id (see GET /api/journey/intents) */
+      intent_id?: string;
+      /** @description Target domain */
+      domain?: string;
+      /** @description The agent configuration that ran (or is running) */
+      agent: {
+        /** @description Agent harness wire name */
+        harness: string;
+        /** @description Model the harness drives */
+        model: string;
+      };
+      started_at: string;
+      finished_at?: string;
+      /** @description SSE stream for this run: run_id -> trajectory -> processing -> result | error */
+      stream_url: string;
+      /**
+       * @description Canonical success verdict, present once the run finished
+       * @enum {string}
+       */
+      verdict?: "satisfied" | "partial" | "unsatisfied" | "not_gradable";
+      /** @description Billable steps the run took (tool calls, excluding narration and filesystem ops), present once the run finished. This is the same counter run pricing uses. */
+      step_count?: number;
+      /** @description Journey/audit contract version (shared SemVer; see docs) */
+      contractVersion: string;
+      /**
+       * @description Marks a per-target-capped response: this is the cached latest run, not a fresh one
+       * @enum {boolean}
+       */
+      rate_limited: true;
+      /** @description The per-target cap that was hit */
+      limit: {
+        /** @description Runs allowed per target per window */
+        max: number;
+        /** @description Window length in ms */
+        window_ms: number;
+      };
+      /** @description Milliseconds until a per-target slot frees */
+      retry_after_ms: number;
+    };
+    JourneyRunDetail: {
+      /** @description Run id - the handle for GET /api/journey/runs/{id} and the stream */
+      id: string;
+      /**
+       * @description Lifecycle status. failed is terminal; a failed run has no result.
+       * @enum {string}
+       */
+      status: "running" | "succeeded" | "failed";
+      /** @description Curated intent id (see GET /api/journey/intents) */
+      intent_id?: string;
+      /** @description Target domain */
+      domain?: string;
+      /** @description The agent configuration that ran (or is running) */
+      agent: {
+        /** @description Agent harness wire name */
+        harness: string;
+        /** @description Model the harness drives */
+        model: string;
+      };
+      started_at: string;
+      finished_at?: string;
+      /** @description SSE stream for this run: run_id -> trajectory -> processing -> result | error */
+      stream_url: string;
+      /**
+       * @description Canonical success verdict, present once the run finished
+       * @enum {string}
+       */
+      verdict?: "satisfied" | "partial" | "unsatisfied" | "not_gradable";
+      /** @description Billable steps the run took (tool calls, excluding narration and filesystem ops), present once the run finished. This is the same counter run pricing uses. */
+      step_count?: number;
+      /** @description Journey/audit contract version (shared SemVer; see docs) */
+      contractVersion: string;
+      /** @description The full run result. Present iff status is 'succeeded'. */
+      result?: {
+        /** @description Run id. Absent on legacy persisted runs. */
+        run_id?: string;
+        /** @description Curated intent id the run executed */
+        intent_id?: string;
+        /** @description Target domain */
+        domain?: string;
+        /** @description Agent harness: claude-agent-sdk | openai-agents | ash */
+        harness?: string;
+        /** @description Model the harness drove */
+        model?: string;
+        started_at?: string;
+        finished_at?: string;
+        /** @description Agent lifecycle outcome. Key 'did it work?' off verdict, not this. */
+        outcome: string;
+        /**
+         * @description Canonical success verdict, judge-authoritative and always resolved (legacy runs included). THE field to key success on.
+         * @enum {string}
+         */
+        verdict: "satisfied" | "partial" | "unsatisfied" | "not_gradable";
+        /** @description The agent's final free-text answer. Experimental: raw model output that can reflect content fetched from the target site - may change or disappear without a major version. */
+        agent_response?: string;
+        /** @description Agent turns the run took */
+        num_turns?: number;
+        /** @description Wall-clock run duration */
+        duration_ms?: number;
+        /** @description The full step tree the agent took */
+        trajectory: {
+          /** @description Cumulative step tree, in emission order */
+          steps: ({
+              /** @description Index in steps[] - stable node identifier */
+              id: number;
+              /** @description Agent turn this step belongs to */
+              turn?: number;
+              /**
+               * @description tool_call = an action against the target; text = narrative reasoning between actions
+               * @enum {string}
+               */
+              type: "tool_call" | "text";
+              /** @description Index of the parent step in this same array (tree edge) */
+              parent_id?: number;
+              /** @description Action family: search | fetch | api_call | text | bash_fs | skill */
+              action?: string;
+              /** @description Concrete tool the harness invoked */
+              tool?: string;
+              /** @description Full URL the step targeted, when it targeted one */
+              url?: string;
+              /** @description Host of the targeted URL */
+              url_host?: string;
+              /** @description Path of the targeted URL */
+              url_path?: string;
+              /** @description Query string, on search steps */
+              search_query?: string;
+              /** @description direct = the agent navigated on its own; follow = it followed a link */
+              source?: string;
+              /** @description Relation of the target to the run's domain: exact | subdomain | external */
+              anchor_relation?: string;
+              /** @description Why the agent went here - the navigation-source attribution */
+              attribution?: {
+                /** @description How the agent found this step: prior_knowledge | web_search | previous_artifact | other */
+                kind: string;
+                /** @description Artifact kind this step was attributed to */
+                artifact_kind?: string;
+                /** @description Signal id backing the attribution, when one matched */
+                signal_id?: string;
+                /** @description Attribution method: heuristic | llm */
+                method?: string;
+                /** @description Attribution confidence: strong | weak */
+                confidence?: string;
+                /** @description The referring step, when attributed to a previous artifact */
+                referrer?: {
+                  /** @description Turn index of the referring step */
+                  turn: number;
+                  /** @description Parent step id - the tree edge the trajectory graph renders */
+                  step_id?: number;
+                  /** @description Artifact kind of the referring step (e.g. llms_txt, sitemap) */
+                  artifact_kind?: string;
+                  /** @description URL path of the referring step */
+                  url_path?: string;
+                };
+              };
+              /** @description Key of the artifact this step fetched, when recognised */
+              artifact_key?: string;
+              /** @description HTTP method of a fetch step */
+              fetch_method?: string;
+              /** @description HTTP status the step observed, once resolved */
+              status?: number;
+              /** @description Wall-clock duration of the step */
+              duration_ms?: number;
+              /** @description Engine-provided display label for the node, when present */
+              label?: string;
+              /** @description tool_call steps only: whether the call has resolved. False while the step is still in flight on a live stream. */
+              completed?: boolean;
+              /** @description Name of the invoked skill, on skill steps */
+              skill_name?: string;
+              /** @description text steps only: the narrative the agent emitted between actions. Advisory - raw model prose. */
+              text?: string;
+            })[];
+          /** @description Compact fingerprint of the action sequence */
+          action_sequence: string;
+          /** @description Ids of agent-readiness signals the run observed */
+          signals_observed: string[];
+          /** @description How the run resolved friction, when classified (e.g. succeeded_natively, needs_human_bridge) */
+          friction_outcome?: string;
+          /** @description HTTP status distribution over the run's requests */
+          status_profile?: {
+            count_2xx: number;
+            count_3xx: number;
+            count_4xx: number;
+            count_5xx: number;
+            /** @description Step id of the first 4xx/5xx, when any */
+            first_error_step?: number;
+            /** @description Artifact kind of the first errored step */
+            first_error_kind?: string;
+          };
+          /** @description Which discovery artifacts the agent probed for, and what it found */
+          well_known_probes: ({
+              /** @description Probed artifact (e.g. llms.txt, openapi.json) */
+              artifact: string;
+              signal_id?: string;
+              /** @description root_file | well_known | api_spec */
+              catalog: string;
+              probed: boolean;
+              fetched: boolean;
+              attempt_count: number;
+              first_status?: number;
+              first_step_ord?: number;
+              first_turn_index?: number;
+              /** @description The agent looked for this artifact and it was absent */
+              near_miss: boolean;
+            })[];
+          /** @description How the agent's visited paths were discovered */
+          path_origin_distribution?: {
+            prior_knowledge: number;
+            web_search: number;
+            previous_artifact: number;
+            other: number;
+          };
+          /** @description Share of navigations that followed an on-page link rather than a guess */
+          link_following_rate: number;
+        };
+        /** @description ora's generated read of the run */
+        insight: {
+          /** @description ora's generated one-paragraph read of the run */
+          summary: string;
+          /** @description Bullet observations backing the summary */
+          key_observations: string[];
+          generated_at: string;
+          /** @description The journey layers this intent touched. NOTE: this is the journey taxonomy (5 layers), deliberately distinct from the audit report's 4 scoring layers - never map between the two. */
+          journey_layers?: ("discovery" | "identity" | "access" | "payments" | "experience")[];
+        };
+        /** @description Flat per-run signal summary. Experimental; absent on legacy runs. */
+        run_signals?: {
+          /** @description run_signals contract version (3 = current) */
+          version: number;
+          /** @description Engine-classified intent category */
+          intent_category: string;
+          /** @description high | low */
+          category_confidence: string;
+          /** @description The independent judge's grade: satisfied | partial | unsatisfied */
+          task_satisfied?: string;
+          /** @description Engine-reconciled success verdict; prefer the top-level verdict field, which is always resolved */
+          verdict?: string;
+          /** @description Agent lifecycle outcome. Key 'did it work?' off the top-level verdict, not this. */
+          outcome: string;
+          friction_outcome?: string;
+          bridge_classification?: string;
+          first_action?: string;
+          /** @description Where the agent went first */
+          first_target?: {
+            page_role: string;
+            anchor_relation?: string;
+            source?: string;
+          };
+          /** @description Engine's raw step count. Display step counts use the record's step_count (billable steps) instead. */
+          steps_count: number;
+          search_count: number;
+          /** @description Whether the agent reached the run's domain at all */
+          reached_anchor: boolean;
+          link_following_rate: number;
+          prior_knowledge_ratio: number;
+          signals_observed: string[];
+          /** @description Per page-role reach summary */
+          page_reach: {
+            [key: string]: {
+              reached: boolean;
+              first_turn: number;
+              steps_to: number;
+            };
+          };
+          /** @description Per artifact probe summary */
+          artifacts: {
+            [key: string]: {
+              probed: boolean;
+              fetched: boolean;
+              first_turn?: number;
+            };
+          };
+          /** @description Step ids on the success path, when the run succeeded */
+          success_step_ids: number[];
+          success_route: {
+            artifacts: {
+              [key: string]: string;
+            };
+            page_roles: {
+              [key: string]: string;
+            };
+            closer?: {
+              artifact_key?: string;
+              page_role?: string;
+            };
+          };
+          /** @description Journey-taxonomy layers (5), distinct from the audit report's 4 scoring layers */
+          journey_layers: ("discovery" | "identity" | "access" | "payments" | "experience")[];
+        };
+      };
+    };
+    JourneyRunResult: {
+      /** @description Run id. Absent on legacy persisted runs. */
+      run_id?: string;
+      /** @description Curated intent id the run executed */
+      intent_id?: string;
+      /** @description Target domain */
+      domain?: string;
+      /** @description Agent harness: claude-agent-sdk | openai-agents | ash */
+      harness?: string;
+      /** @description Model the harness drove */
+      model?: string;
+      started_at?: string;
+      finished_at?: string;
+      /** @description Agent lifecycle outcome. Key 'did it work?' off verdict, not this. */
+      outcome: string;
+      /**
+       * @description Canonical success verdict, judge-authoritative and always resolved (legacy runs included). THE field to key success on.
+       * @enum {string}
+       */
+      verdict: "satisfied" | "partial" | "unsatisfied" | "not_gradable";
+      /** @description The agent's final free-text answer. Experimental: raw model output that can reflect content fetched from the target site - may change or disappear without a major version. */
+      agent_response?: string;
+      /** @description Agent turns the run took */
+      num_turns?: number;
+      /** @description Wall-clock run duration */
+      duration_ms?: number;
+      /** @description The full step tree the agent took */
+      trajectory: {
+        /** @description Cumulative step tree, in emission order */
+        steps: ({
+            /** @description Index in steps[] - stable node identifier */
+            id: number;
+            /** @description Agent turn this step belongs to */
+            turn?: number;
+            /**
+             * @description tool_call = an action against the target; text = narrative reasoning between actions
+             * @enum {string}
+             */
+            type: "tool_call" | "text";
+            /** @description Index of the parent step in this same array (tree edge) */
+            parent_id?: number;
+            /** @description Action family: search | fetch | api_call | text | bash_fs | skill */
+            action?: string;
+            /** @description Concrete tool the harness invoked */
+            tool?: string;
+            /** @description Full URL the step targeted, when it targeted one */
+            url?: string;
+            /** @description Host of the targeted URL */
+            url_host?: string;
+            /** @description Path of the targeted URL */
+            url_path?: string;
+            /** @description Query string, on search steps */
+            search_query?: string;
+            /** @description direct = the agent navigated on its own; follow = it followed a link */
+            source?: string;
+            /** @description Relation of the target to the run's domain: exact | subdomain | external */
+            anchor_relation?: string;
+            /** @description Why the agent went here - the navigation-source attribution */
+            attribution?: {
+              /** @description How the agent found this step: prior_knowledge | web_search | previous_artifact | other */
+              kind: string;
+              /** @description Artifact kind this step was attributed to */
+              artifact_kind?: string;
+              /** @description Signal id backing the attribution, when one matched */
+              signal_id?: string;
+              /** @description Attribution method: heuristic | llm */
+              method?: string;
+              /** @description Attribution confidence: strong | weak */
+              confidence?: string;
+              /** @description The referring step, when attributed to a previous artifact */
+              referrer?: {
+                /** @description Turn index of the referring step */
+                turn: number;
+                /** @description Parent step id - the tree edge the trajectory graph renders */
+                step_id?: number;
+                /** @description Artifact kind of the referring step (e.g. llms_txt, sitemap) */
+                artifact_kind?: string;
+                /** @description URL path of the referring step */
+                url_path?: string;
+              };
+            };
+            /** @description Key of the artifact this step fetched, when recognised */
+            artifact_key?: string;
+            /** @description HTTP method of a fetch step */
+            fetch_method?: string;
+            /** @description HTTP status the step observed, once resolved */
+            status?: number;
+            /** @description Wall-clock duration of the step */
+            duration_ms?: number;
+            /** @description Engine-provided display label for the node, when present */
+            label?: string;
+            /** @description tool_call steps only: whether the call has resolved. False while the step is still in flight on a live stream. */
+            completed?: boolean;
+            /** @description Name of the invoked skill, on skill steps */
+            skill_name?: string;
+            /** @description text steps only: the narrative the agent emitted between actions. Advisory - raw model prose. */
+            text?: string;
+          })[];
+        /** @description Compact fingerprint of the action sequence */
+        action_sequence: string;
+        /** @description Ids of agent-readiness signals the run observed */
+        signals_observed: string[];
+        /** @description How the run resolved friction, when classified (e.g. succeeded_natively, needs_human_bridge) */
+        friction_outcome?: string;
+        /** @description HTTP status distribution over the run's requests */
+        status_profile?: {
+          count_2xx: number;
+          count_3xx: number;
+          count_4xx: number;
+          count_5xx: number;
+          /** @description Step id of the first 4xx/5xx, when any */
+          first_error_step?: number;
+          /** @description Artifact kind of the first errored step */
+          first_error_kind?: string;
+        };
+        /** @description Which discovery artifacts the agent probed for, and what it found */
+        well_known_probes: ({
+            /** @description Probed artifact (e.g. llms.txt, openapi.json) */
+            artifact: string;
+            signal_id?: string;
+            /** @description root_file | well_known | api_spec */
+            catalog: string;
+            probed: boolean;
+            fetched: boolean;
+            attempt_count: number;
+            first_status?: number;
+            first_step_ord?: number;
+            first_turn_index?: number;
+            /** @description The agent looked for this artifact and it was absent */
+            near_miss: boolean;
+          })[];
+        /** @description How the agent's visited paths were discovered */
+        path_origin_distribution?: {
+          prior_knowledge: number;
+          web_search: number;
+          previous_artifact: number;
+          other: number;
+        };
+        /** @description Share of navigations that followed an on-page link rather than a guess */
+        link_following_rate: number;
+      };
+      /** @description ora's generated read of the run */
+      insight: {
+        /** @description ora's generated one-paragraph read of the run */
+        summary: string;
+        /** @description Bullet observations backing the summary */
+        key_observations: string[];
+        generated_at: string;
+        /** @description The journey layers this intent touched. NOTE: this is the journey taxonomy (5 layers), deliberately distinct from the audit report's 4 scoring layers - never map between the two. */
+        journey_layers?: ("discovery" | "identity" | "access" | "payments" | "experience")[];
+      };
+      /** @description Flat per-run signal summary. Experimental; absent on legacy runs. */
+      run_signals?: {
+        /** @description run_signals contract version (3 = current) */
+        version: number;
+        /** @description Engine-classified intent category */
+        intent_category: string;
+        /** @description high | low */
+        category_confidence: string;
+        /** @description The independent judge's grade: satisfied | partial | unsatisfied */
+        task_satisfied?: string;
+        /** @description Engine-reconciled success verdict; prefer the top-level verdict field, which is always resolved */
+        verdict?: string;
+        /** @description Agent lifecycle outcome. Key 'did it work?' off the top-level verdict, not this. */
+        outcome: string;
+        friction_outcome?: string;
+        bridge_classification?: string;
+        first_action?: string;
+        /** @description Where the agent went first */
+        first_target?: {
+          page_role: string;
+          anchor_relation?: string;
+          source?: string;
+        };
+        /** @description Engine's raw step count. Display step counts use the record's step_count (billable steps) instead. */
+        steps_count: number;
+        search_count: number;
+        /** @description Whether the agent reached the run's domain at all */
+        reached_anchor: boolean;
+        link_following_rate: number;
+        prior_knowledge_ratio: number;
+        signals_observed: string[];
+        /** @description Per page-role reach summary */
+        page_reach: {
+          [key: string]: {
+            reached: boolean;
+            first_turn: number;
+            steps_to: number;
+          };
+        };
+        /** @description Per artifact probe summary */
+        artifacts: {
+          [key: string]: {
+            probed: boolean;
+            fetched: boolean;
+            first_turn?: number;
+          };
+        };
+        /** @description Step ids on the success path, when the run succeeded */
+        success_step_ids: number[];
+        success_route: {
+          artifacts: {
+            [key: string]: string;
+          };
+          page_roles: {
+            [key: string]: string;
+          };
+          closer?: {
+            artifact_key?: string;
+            page_role?: string;
+          };
+        };
+        /** @description Journey-taxonomy layers (5), distinct from the audit report's 4 scoring layers */
+        journey_layers: ("discovery" | "identity" | "access" | "payments" | "experience")[];
+      };
+    };
+    JourneyTrajectoryStep: {
+      /** @description Index in steps[] - stable node identifier */
+      id: number;
+      /** @description Agent turn this step belongs to */
+      turn?: number;
+      /**
+       * @description tool_call = an action against the target; text = narrative reasoning between actions
+       * @enum {string}
+       */
+      type: "tool_call" | "text";
+      /** @description Index of the parent step in this same array (tree edge) */
+      parent_id?: number;
+      /** @description Action family: search | fetch | api_call | text | bash_fs | skill */
+      action?: string;
+      /** @description Concrete tool the harness invoked */
+      tool?: string;
+      /** @description Full URL the step targeted, when it targeted one */
+      url?: string;
+      /** @description Host of the targeted URL */
+      url_host?: string;
+      /** @description Path of the targeted URL */
+      url_path?: string;
+      /** @description Query string, on search steps */
+      search_query?: string;
+      /** @description direct = the agent navigated on its own; follow = it followed a link */
+      source?: string;
+      /** @description Relation of the target to the run's domain: exact | subdomain | external */
+      anchor_relation?: string;
+      /** @description Why the agent went here - the navigation-source attribution */
+      attribution?: {
+        /** @description How the agent found this step: prior_knowledge | web_search | previous_artifact | other */
+        kind: string;
+        /** @description Artifact kind this step was attributed to */
+        artifact_kind?: string;
+        /** @description Signal id backing the attribution, when one matched */
+        signal_id?: string;
+        /** @description Attribution method: heuristic | llm */
+        method?: string;
+        /** @description Attribution confidence: strong | weak */
+        confidence?: string;
+        /** @description The referring step, when attributed to a previous artifact */
+        referrer?: {
+          /** @description Turn index of the referring step */
+          turn: number;
+          /** @description Parent step id - the tree edge the trajectory graph renders */
+          step_id?: number;
+          /** @description Artifact kind of the referring step (e.g. llms_txt, sitemap) */
+          artifact_kind?: string;
+          /** @description URL path of the referring step */
+          url_path?: string;
+        };
+      };
+      /** @description Key of the artifact this step fetched, when recognised */
+      artifact_key?: string;
+      /** @description HTTP method of a fetch step */
+      fetch_method?: string;
+      /** @description HTTP status the step observed, once resolved */
+      status?: number;
+      /** @description Wall-clock duration of the step */
+      duration_ms?: number;
+      /** @description Engine-provided display label for the node, when present */
+      label?: string;
+      /** @description tool_call steps only: whether the call has resolved. False while the step is still in flight on a live stream. */
+      completed?: boolean;
+      /** @description Name of the invoked skill, on skill steps */
+      skill_name?: string;
+      /** @description text steps only: the narrative the agent emitted between actions. Advisory - raw model prose. */
+      text?: string;
     };
     /** @description The default response body of POST /api/scan and GET /api/score/{domain}. Fields not listed below may be present: they are ora internals, are not part of the contract, and may change or disappear in any release without a major version bump. Pass `?format=audit` for the versioned, fully documented shape (AuditScanResult / AuditScoreResult). */
     ScanResult: {
@@ -1425,6 +2075,204 @@ export interface operations {
       /** @description JWKS generation failed */
       500: {
         content: never;
+      };
+    };
+  };
+  /**
+   * Run an agent journey against a domain
+   * @description Triggers a real agent run: an AI agent (harness + model) attempts a curated task (an intent) against the given domain, and ora records the trajectory and derives insights. Two-step flow: this endpoint returns fast with a run record whose `stream_url` serves the live trajectory as Server-Sent Events; poll GET /api/journey/runs/{id} instead if you do not want the stream. Only curated intents run publicly (see GET /api/journey/intents) - the server derives the actual agent prompt from the intent id, so no free-text prompt can reach the engine. Only publicly runnable agents are accepted (see GET /api/journey/agents). Unknown body fields are rejected (strict schema). Rate limited three ways: a 20-per-minute burst cap per IP; a per-target cap of 5 runs per rolling 24h per (domain, intent, harness, model) - when a target is over the cap the response is HTTP 200 with the most recent stored run for that target (`rate_limited: true`) plus Retry-After, the freshness analog: a denied trigger still returns the newest result and consumes nothing; and a durable per-caller cap of 10 runs per rolling 24h per IP - exceeded, that one is a real 429 with `retry_after_ms` (there is no cached result to serve for a caller). Successful and capped responses carry X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset headers for the per-target window. Note: journey insights use the 5-layer journey taxonomy (discovery, identity, access, payments, experience), deliberately distinct from the 4 scoring layers of the audit report (POST /api/scan) - never map between the two.
+   */
+  createJourneyRun: {
+    requestBody: {
+      content: {
+        "application/json": {
+          intent: {
+            /**
+             * @description Curated intent to execute (GET /api/journey/intents lists them with labels)
+             * @enum {string}
+             */
+            intent_id: "pricing" | "signup" | "api-docs" | "integrate" | "support" | "evaluate" | "discover-trust" | "agent-access" | "understand-offering" | "find-integration" | "inspect-integration" | "production-readiness" | "authenticate" | "transact" | "act-for-user" | "operate-site";
+            /**
+             * @description Target domain (e.g. stripe.com). Validated like a scan target: IP literals, localhost, and malformed hosts are rejected with code INVALID_DOMAIN.
+             * @example stripe.com
+             */
+            domain?: string;
+          };
+          /**
+           * @description Agent harness wire name. The (harness, model) pair must resolve to a publicly runnable agent from GET /api/journey/agents, else 400 UNSUPPORTED_AGENT.
+           * @enum {string}
+           */
+          harness: "claude-agent-sdk" | "openai-agents" | "ash";
+          /**
+           * @description Model the harness drives (e.g. claude-haiku-4-5)
+           * @example claude-haiku-4-5
+           */
+          model: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Per-target cap hit - the freshness analog, not an error: the body is the most recent stored run for this exact (domain, intent, harness, model) target, marked `rate_limited: true`, so CI and agents get the newest result without spending a run. Replay it via its `stream_url`. */
+      200: {
+        headers: {
+          /** @description Seconds until the target's oldest in-window run ages out */
+          "Retry-After"?: number;
+        };
+        content: {
+          "application/json": components["schemas"]["JourneyCappedRun"];
+        };
+      };
+      /** @description Run created and dispatched. Open `stream_url` (SSE) to watch the trajectory live, or poll GET /api/journey/runs/{id}. */
+      201: {
+        headers: {
+          /** @description Per-target window size (5 runs per rolling 24h) */
+          "X-RateLimit-Limit"?: number;
+          /** @description Runs left in this target's window, including this one's consumption */
+          "X-RateLimit-Remaining"?: number;
+          /** @description Unix seconds when the next per-target slot frees. Absent when the window was empty. */
+          "X-RateLimit-Reset"?: number;
+        };
+        content: {
+          "application/json": components["schemas"]["JourneyRun"];
+        };
+      };
+      /** @description Invalid input: schema failure (including unknown body fields - the contract is strict), `code: "INVALID_DOMAIN"` for a domain the scanner would reject, or `code: "UNSUPPORTED_AGENT"` for a (harness, model) pair that is not publicly runnable. */
+      400: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+      /** @description Caller limit exceeded - the 20-per-minute burst cap, or the durable per-caller budget (10 runs per rolling 24h per IP; body carries `retry_after_ms`). Per-TARGET saturation is the 200 above, not this. */
+      429: {
+        headers: {
+          /** @description Seconds until next allowed request */
+          "Retry-After"?: number;
+        };
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+      /** @description The run engine could not be reached; nothing was created or consumed. */
+      503: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * Get a journey run record (non-streaming)
+   * @description Returns the run record by id. While the run executes, `status` is 'running' - open the stream or poll. Once finished and persisted, `status` is 'succeeded' and the body carries `verdict`, `step_count` (billable steps - the same counter run pricing uses), and the full `result` (trajectory + insight + signals). `status` 'failed' is terminal with no result. `result` is present iff status is 'succeeded'.
+   */
+  getJourneyRun: {
+    parameters: {
+      path: {
+        /** @description The run id from POST /api/journey/runs */
+        id: string;
+      };
+    };
+    responses: {
+      /** @description The run record; plus `result` once succeeded. */
+      200: {
+        content: {
+          "application/json": components["schemas"]["JourneyRunDetail"];
+        };
+      };
+      /** @description Unknown run id */
+      404: {
+        content: never;
+      };
+    };
+  };
+  /**
+   * Stream a journey run's trajectory as Server-Sent Events
+   * @description The live trajectory SSE for a run created by POST /api/journey/runs. Event names (stable): `run_id` ({ run_id }), then progressive `trajectory` frames (cumulative snapshots, each a { steps, ... } object of JourneyTrajectoryStep items), optionally `processing` ({ message }) while insights generate, and finally exactly one of `result` (a JourneyRunResult) or `error` ({ message }). Reopening the stream of a finished run replays the stored result instead of re-executing the agent (pass ?replay=1 for paced frames, plus &quick=1 to skip the startup delay); a plain reopen renders the finished journey in one frame. Long-lived: a live run can hold the connection for many minutes (function ceiling 800s). Rate limited 20 per minute per IP.
+   */
+  streamJourneyRun: {
+    parameters: {
+      query?: {
+        /** @description Pass 1 to replay a finished run as paced progressive frames (the animated replay). */
+        replay?: "1";
+        /** @description With replay=1: skip the startup delay. */
+        quick?: "1";
+      };
+      path: {
+        /** @description The run id */
+        id: string;
+      };
+    };
+    responses: {
+      /** @description Server-Sent Events stream: run_id -> trajectory* -> processing? -> result | error. */
+      200: {
+        content: {
+          "text/event-stream": string;
+        };
+      };
+      /** @description Unknown run id */
+      404: {
+        content: never;
+      };
+      /** @description Rate limit exceeded - max 20 requests per minute per IP. */
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+    };
+  };
+  /**
+   * List the curated journey intents
+   * @description The curated tasks a public journey run can execute. Each entry carries the stable `id` (what POST /api/journey/runs takes), a short `label`, a one-line `hint`, and the user-facing `template` phrasing. Cached statically.
+   */
+  listJourneyIntents: {
+    responses: {
+      /** @description Curated intents plus the default id. */
+      200: {
+        content: {
+          "application/json": {
+            intents?: {
+                /** @description Stable intent id */
+                id?: string;
+                /** @description Short picker label */
+                label?: string;
+                /** @description One-line description of the job to be done */
+                hint?: string;
+                /** @description User-facing phrasing of the task */
+                template?: string;
+              }[];
+            defaultId?: string;
+          };
+        };
+      };
+    };
+  };
+  /**
+   * List the publicly runnable journey agents
+   * @description The agents an anonymous POST /api/journey/runs accepts - every listed (harness, model) pair is publicly runnable. Entries carry display metadata (label, variant, brand, blurb) plus the wire fields `harness` and `model`. Cached statically.
+   */
+  listJourneyAgents: {
+    responses: {
+      /** @description Runnable agents plus the default picker id. */
+      200: {
+        content: {
+          "application/json": {
+            agents?: {
+                /** @description Picker id */
+                id?: string;
+                label?: string;
+                variant?: string;
+                brand?: string;
+                /** @description Wire harness for POST /api/journey/runs */
+                harness?: string;
+                /** @description Wire model for POST /api/journey/runs */
+                model?: string;
+                agentLabel?: string;
+                blurb?: string;
+                badge?: string;
+              }[];
+            defaultId?: string;
+          };
+        };
       };
     };
   };

--- a/src/contract/types.gen.ts
+++ b/src/contract/types.gen.ts
@@ -590,6 +590,16 @@ export interface components {
         num_turns?: number;
         /** @description Wall-clock run duration */
         duration_ms?: number;
+        /** @description Model spend for the run in USD. Experimental: tracks provider accounting and may change or disappear without a major version. */
+        cost_usd?: number;
+        /** @description Total input tokens the run consumed. Experimental. */
+        input_tokens?: number;
+        /** @description Total output tokens the run produced. Experimental. */
+        output_tokens?: number;
+        /** @description Prompt-cache read tokens. Experimental. */
+        cache_read_tokens?: number;
+        /** @description Prompt-cache write tokens. Experimental. */
+        cache_write_tokens?: number;
         /** @description The full step tree the agent took */
         trajectory: {
           /** @description Cumulative step tree, in emission order */
@@ -807,6 +817,16 @@ export interface components {
       num_turns?: number;
       /** @description Wall-clock run duration */
       duration_ms?: number;
+      /** @description Model spend for the run in USD. Experimental: tracks provider accounting and may change or disappear without a major version. */
+      cost_usd?: number;
+      /** @description Total input tokens the run consumed. Experimental. */
+      input_tokens?: number;
+      /** @description Total output tokens the run produced. Experimental. */
+      output_tokens?: number;
+      /** @description Prompt-cache read tokens. Experimental. */
+      cache_read_tokens?: number;
+      /** @description Prompt-cache write tokens. Experimental. */
+      cache_write_tokens?: number;
       /** @description The full step tree the agent took */
       trajectory: {
         /** @description Cumulative step tree, in emission order */
@@ -2112,11 +2132,17 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Per-target cap hit - the freshness analog, not an error: the body is the most recent stored run for this exact (domain, intent, harness, model) target, marked `rate_limited: true`, so CI and agents get the newest result without spending a run. Replay it via its `stream_url`. */
+      /** @description Per-target cap hit - the freshness analog, not an error: the body is the most recent stored run for this exact (domain, intent, harness, model) target, marked `rate_limited: true`, so CI and agents get the newest result without spending a run. When the served run has finished, the body also carries `verdict` and `step_count`. Replay it via its `stream_url`. */
       200: {
         headers: {
           /** @description Seconds until the target's oldest in-window run ages out */
           "Retry-After"?: number;
+          /** @description Per-target window size (5 runs per rolling 24h) */
+          "X-RateLimit-Limit"?: number;
+          /** @description Always 0 on a capped response */
+          "X-RateLimit-Remaining"?: number;
+          /** @description Unix seconds when the next per-target slot frees */
+          "X-RateLimit-Reset"?: number;
         };
         content: {
           "application/json": components["schemas"]["JourneyCappedRun"];

--- a/src/contract/version.ts
+++ b/src/contract/version.ts
@@ -2,4 +2,4 @@
 // Regenerate: pnpm contract:gen [--url <openapi.json url>]
 
 /** The ora contract version (spec info.version) these types were generated from. */
-export const BUILT_AGAINST = "1.8.0";
+export const BUILT_AGAINST = "1.9.0";

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,17 @@ export {
 	performAudit as audit,
 } from "./api/audit";
 export {
+	DeepJourneyApiError,
+	type DeepJourneyOptions,
+	type DeepJourneyOutcome,
+	fetchJourneyAgents,
+	fetchJourneyIntents,
+	type JourneyAgentOption,
+	type JourneyIntentOption,
+	performDeepJourney as deepJourney,
+	type RunAllowance,
+} from "./api/deep-journey";
+export {
 	type FetchedSkill,
 	fetchSkill,
 	fetchSkillIndex,
@@ -25,4 +36,9 @@ export {
 	type AuditTopFix,
 	BUILT_AGAINST,
 	isNewerContract,
+	type JourneyCappedRun,
+	type JourneyRun,
+	type JourneyRunDetail,
+	type JourneyRunResult,
+	type JourneyTrajectoryStep,
 } from "./contract";

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { defineCommand, runMain } from "citty";
 import pc from "picocolors";
 import pkg from "../package.json";
 import { auditCommand } from "./commands/audit";
+import { deepJourneyCommand } from "./commands/deep-journey";
 import { journeyCommand } from "./commands/journey";
 import { skillCommand } from "./commands/skill";
 import { loadLocalEnv } from "./env";
@@ -103,6 +104,49 @@ const journey = defineCommand({
 	},
 });
 
+const deepJourney = defineCommand({
+	meta: {
+		name: "deep-journey",
+		description:
+			"Run a real AI agent at a site on a curated task via ora's public API (no key needed; exit codes: 0 ok, 1 run failed, 2 usage, 3 API error)",
+	},
+	args: {
+		url: {
+			type: "positional",
+			description: "URL or domain the agent targets (e.g. stripe.com)",
+			required: true,
+		},
+		intent: {
+			type: "string",
+			description: "Curated intent id (see GET /api/journey/intents; server default when omitted)",
+		},
+		agent: {
+			type: "string",
+			description: "Agent id from the public roster (see GET /api/journey/agents)",
+		},
+		json: {
+			type: "boolean",
+			description: "Print the terminal run detail as JSON",
+			default: false,
+		},
+		"no-stream": {
+			type: "boolean",
+			description: "Skip the live trajectory stream and poll for the result instead",
+			default: false,
+		},
+	},
+	async run({ args }) {
+		// Same exitCode-over-exit rule as audit: let stdout drain before exiting.
+		process.exitCode = await deepJourneyCommand({
+			url: args.url as string,
+			intent: args.intent as string | undefined,
+			agent: args.agent as string | undefined,
+			json: Boolean(args.json),
+			noStream: Boolean(args["no-stream"]),
+		});
+	},
+});
+
 const skill = defineCommand({
 	meta: {
 		name: "skill",
@@ -145,14 +189,16 @@ function helpScreen(): string {
 		`  ${d("Score any site's agent readiness — and watch real AI agents navigate it")}`,
 		"",
 		`  ${d("Commands:")}`,
-		`    audit ${d("<url>")}       ${d("Score a site's agent readiness")}`,
-		`    journey ${d("<intent>")}  ${d("Send a real agent at a site and watch it live")}`,
-		`    skill ${d("[name]")}      ${d("List, print, or install ora's agent skills")}`,
+		`    audit ${d("<url>")}         ${d("Score a site's agent readiness")}`,
+		`    deep-journey ${d("<url>")}  ${d("Run a real agent at a site on a curated task (no key needed)")}`,
+		`    journey ${d("<intent>")}    ${d("Send a real agent at a site and watch it live (workspace)")}`,
+		`    skill ${d("[name]")}        ${d("List, print, or install ora's agent skills")}`,
 		"",
 		`  ${d("Examples:")}`,
 		`    ${g} ${NAME} audit https://docs.example.com`,
 		`    ${g} ${NAME} audit https://docs.example.com --min-score 70   ${d("# CI gate")}`,
 		`    ${g} ${NAME} audit https://docs.example.com --json`,
+		`    ${g} ${NAME} deep-journey stripe.com --intent pricing`,
 		`    ${g} ${NAME} journey "Find the API docs and how to authenticate" --domain stripe.com`,
 		"",
 		`  ${d("audit options:")}`,
@@ -166,6 +212,13 @@ function helpScreen(): string {
 		"",
 		`  ${d("audit exit codes:")}`,
 		`    ${d("0 success · 1 below --min-score · 2 usage error · 3 API unreachable/rate-limited")}`,
+		"",
+		`  ${d("deep-journey options:")}`,
+		`    --intent <id>    ${d("Curated task id, e.g. pricing, signup, api-docs (server default when omitted)")}`,
+		`    --agent <id>     ${d("Agent from the public roster (default: ora's pick)")}`,
+		`    --no-stream      ${d("Poll for the result instead of streaming the trajectory")}`,
+		`    --json           ${d("Print the terminal run detail as JSON")}`,
+		`    ${d("no key needed · public caps: 5 runs/24h per target, 10 runs/24h per IP")}`,
 		"",
 		`  ${d("journey options:")}`,
 		`    --domain <d>     ${d("Site the agent targets (e.g. stripe.com)")}`,
@@ -183,7 +236,7 @@ const root = defineCommand({
 		version: pkg.version,
 		description: "Score any site's agent readiness — and watch real AI agents navigate it",
 	},
-	subCommands: { audit, journey, skill },
+	subCommands: { audit, "deep-journey": deepJourney, journey, skill },
 	setup() {
 		// Bare invocation and top-level --help get the curated screen; subcommand
 		// --help stays with citty's generated usage.


### PR DESCRIPTION
## What

`ax deep-journey <url> [--intent <id>] [--agent <harness>/<model>] [--no-stream] [--json]` - drives ora's public journey API (contract 1.9.0, no key needed): resolves the curated intent + agent rosters from the live endpoints, triggers a run, streams the trajectory as progress lines, and renders the terminal verdict, billable `step_count`, and insight verbatim from the contract.

- Per-target-capped trigger renders the stored latest run with a retry hint instead of erroring; the durable per-IP 429 maps to an actionable message. Public caps shown up front; remaining target allowance read from the `X-RateLimit-*` headers.
- `--no-stream` polls `GET /api/journey/runs/{id}`; `--json` prints the terminal detail. Exit codes: 0 succeeded (any verdict), 1 run failed, 2 usage, 3 API.
- Prints one cross-hint after a journey: `ax audit <url>` (the two taxonomies stay unmapped by design).

## Contract

Types regenerated from the **production** spec at 1.9.0 - including the post-review additions (run-level `cost_usd` + token aggregates as experimental fields, capped-200 `verdict` + `step_count`, `X-RateLimit` headers). The merge gate from the commit ("do not merge before ora.ai serves 1.9.0") is cleared: production verified serving 1.9.0 with all five journey paths and components.

## Verification

- `test:ci`, `typecheck`, `lint`, `build` all green on the merged branch.
- End-to-end run against the ora dev server during development; contract fixture recorded from a real projected `GET /api/journey/runs/{id}` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)