### PR TITLE
feat: scan API key lifts the audit rate limits (--api-key / ORA_SCAN_API_KEY)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ ORA_PLATFORM_URL=https://api.agentfront.sh
 # Tunnel command for auditing a local target (same as --tunnel-cmd):
 # a command that exposes the local server and prints its public https URL.
 # ORA_TUNNEL_CMD='ngrok http 3000 --log stdout'
+
+# ora-issued scan API key for `ax audit` (same as --api-key): exempts the
+# caller from the scan rate limits (30/day + 6 force/day + 10/min burst).
+# Issued manually by ora — no self-serve signup. Leave unset for normal use.
+# ORA_SCAN_API_KEY=

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Three commands:
 ## audit
 
 ```
-ax audit <url> [--min-score n] [--max-age s] [--force] [--tunnel-cmd c] [--json] [--show-passing] [--show-skipped]
+ax audit <url> [--min-score n] [--max-age s] [--force] [--tunnel-cmd c] [--api-key k] [--json] [--show-passing] [--show-skipped]
 ```
 
 ```
@@ -46,6 +46,7 @@ ax audit <url> [--min-score n] [--max-age s] [--force] [--tunnel-cmd c] [--json]
 | `--max-age <s>` | Accept a cached result up to `s` seconds old (server default 6h, clamped to 1-24h) |
 | `--force` | Bypass the cache and rescan — spends the stricter 6/day force budget |
 | `--tunnel-cmd <c>` | Expose a local target through your own tunnel command and audit the public URL it prints (also read from `ORA_TUNNEL_CMD`) |
+| `--api-key <k>` | ora-issued scan API key — lifts every scan rate limit (also read from `ORA_SCAN_API_KEY`) |
 | `--json` | The raw ora audit payload on stdout, exactly as the API served it |
 | `--show-passing` | List every passing check, not just the per-layer summary bar |
 | `--show-skipped` | Include not-applicable/pending checks with their reason |
@@ -68,7 +69,7 @@ Exit codes are the contract:
 | `2` | usage error — bad flags, malformed URL, local target without a tunnel |
 | `3` | API unreachable, timeout, or rate limit exhausted |
 
-Budget notes: ora allows 30 scans + 6 `--force` scans per rolling 24h per IP (plus a 10/min burst limit). Results served from the freshness cache cost nothing, so a CI job that audits on every push stays well inside the budget — tune the window with `--max-age`, and reserve `--force` for verifying a fix you just deployed. An auth-gated MCP target reports `mcpAuthRequired` and scores 0 as "could not evaluate"; `--min-score` deliberately skips the gate rather than failing on it.
+Budget notes: ora allows 30 scans + 6 `--force` scans per rolling 24h per IP (plus a 10/min burst limit). Results served from the freshness cache cost nothing, so a CI job that audits on every push stays well inside the budget — tune the window with `--max-age`, and reserve `--force` for verifying a fix you just deployed. High-volume callers can present an ora-issued scan API key (`--api-key` or `ORA_SCAN_API_KEY`), which exempts them from all of these limits; keys are issued manually by ora (no self-serve signup), and an unrecognized key silently falls back to the keyless limits rather than erroring. An auth-gated MCP target reports `mcpAuthRequired` and scores 0 as "could not evaluate"; `--min-score` deliberately skips the gate rather than failing on it.
 
 ### Auditing localhost (`--tunnel-cmd`)
 
@@ -232,6 +233,7 @@ A `.env` in the working directory is read on startup — copy `.env.example` and
 | `ORA_API_URL` | audit, deep-journey, skill | `https://ora.ai` | Public API base (no auth) |
 | `ORA_PLATFORM_URL` | journey | `https://api.agentfront.sh` | Authenticated platform API base |
 | `ORA_API_KEY` | journey | — (required) | Secret key (`ora_sk_…`), exchanged for a short-lived bearer token |
+| `ORA_SCAN_API_KEY` | audit | — (optional) | ora-issued scan API key; lifts every scan rate limit (issued manually by ora) |
 
 ## Contract versioning
 

--- a/src/api/audit.test.ts
+++ b/src/api/audit.test.ts
@@ -189,12 +189,100 @@ describe("performAudit", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
 
-	it("explains the rate limits on 429", async () => {
+	it("explains the rate limits on 429 and points at the key that lifts them", async () => {
 		vi.stubGlobal(
 			"fetch",
 			vi.fn(async () => new Response("{}", { status: 429, headers: { "retry-after": "42" } })),
 		);
 		await expect(performAudit("example.com")).rejects.toThrow(/rate limit.*42s/i);
+		await expect(performAudit("example.com")).rejects.toThrow(/ORA_SCAN_API_KEY/);
+	});
+
+	describe("scan API key", () => {
+		// The key lifts ora's scan rate limits (keyed exemption, contract 1.10.0).
+		// The server tolerates any bearer token — unrecognized degrades to keyless —
+		// so the only client obligation is putting the right key on the right calls.
+		const headersOf = (init?: RequestInit): Record<string, string> =>
+			(init?.headers ?? {}) as Record<string, string>;
+
+		afterEach(() => vi.unstubAllEnvs());
+
+		it("sends the key as a bearer token on the stream request", async () => {
+			const auths: (string | undefined)[] = [];
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async (_url: string | URL, init?: RequestInit) => {
+					auths.push(headersOf(init).authorization);
+					return scanStream([{ type: "scan_complete", result: settled() }]);
+				}),
+			);
+
+			await performAudit("example.com", { apiKey: "sk_live_abc" });
+			expect(auths).toEqual(["Bearer sk_live_abc"]);
+		});
+
+		it("reads the key from ORA_SCAN_API_KEY when no option is given", async () => {
+			vi.stubEnv("ORA_SCAN_API_KEY", "sk_env_key");
+			const auths: (string | undefined)[] = [];
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async (_url: string | URL, init?: RequestInit) => {
+					auths.push(headersOf(init).authorization);
+					return scanStream([{ type: "scan_complete", result: settled() }]);
+				}),
+			);
+
+			await performAudit("example.com");
+			expect(auths).toEqual(["Bearer sk_env_key"]);
+		});
+
+		it("prefers an explicit key over the environment", async () => {
+			vi.stubEnv("ORA_SCAN_API_KEY", "sk_env_key");
+			const auths: (string | undefined)[] = [];
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async (_url: string | URL, init?: RequestInit) => {
+					auths.push(headersOf(init).authorization);
+					return scanStream([{ type: "scan_complete", result: settled() }]);
+				}),
+			);
+
+			await performAudit("example.com", { apiKey: "sk_flag_key" });
+			expect(auths).toEqual(["Bearer sk_flag_key"]);
+		});
+
+		it("sends no authorization header when no key is set", async () => {
+			// An empty env value (unset CI variable expanding to "") counts as absent.
+			vi.stubEnv("ORA_SCAN_API_KEY", "");
+			const auths: (string | undefined)[] = [];
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async (_url: string | URL, init?: RequestInit) => {
+					auths.push(headersOf(init).authorization);
+					return scanStream([{ type: "scan_complete", result: settled() }]);
+				}),
+			);
+
+			await performAudit("example.com");
+			expect(auths).toEqual([undefined]);
+		});
+
+		it("authorizes the deep-analysis poll with the same key", async () => {
+			const halfway = settled({ analysisStatus: "partial", pendingChecks: ["crawl"] });
+			const auths: (string | undefined)[] = [];
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async (_url: string | URL, init?: RequestInit) => {
+					auths.push(headersOf(init).authorization);
+					return auths.length === 1
+						? scanStream([{ type: "scan_complete", result: halfway }])
+						: asJson(settled());
+				}),
+			);
+
+			await performAudit("example.com", { apiKey: "sk_live_abc", pollEveryMs: 0 });
+			expect(auths).toEqual(["Bearer sk_live_abc", "Bearer sk_live_abc"]);
+		});
 	});
 
 	it("surfaces the server's message on a 4xx response", async () => {

--- a/src/api/audit.ts
+++ b/src/api/audit.ts
@@ -51,6 +51,17 @@ export interface AuditOptions {
 	force?: boolean;
 	/** Store the result as disposable (tunnel hosts are auto-classified). */
 	ephemeral?: boolean;
+	/**
+	 * ora-issued scan API key (contract 1.10.0): exempts the caller from every
+	 * scan-family rate limit. Falls back to $ORA_SCAN_API_KEY. Safe to send
+	 * blind — the server degrades an unrecognized key to keyless, never a 401.
+	 */
+	apiKey?: string;
+}
+
+/** Bearer header for the scan API key, or nothing when the caller is keyless. */
+function authHeaders(apiKey: string | undefined): Record<string, string> {
+	return apiKey ? { authorization: `Bearer ${apiKey}` } : {};
 }
 
 /**
@@ -64,6 +75,10 @@ export async function performAudit(
 	options: AuditOptions = {},
 ): Promise<AuditOutcome> {
 	const base = (options.baseUrl ?? process.env.ORA_API_URL ?? PUBLIC_BASE).replace(/\/+$/, "");
+	// Resolve the key once so the stream request and the deep-analysis poll
+	// agree — the poll target is rate limited too, and a keyed scan whose polls
+	// went keyless would throttle exactly the high-volume callers keys exist for.
+	options = { ...options, apiKey: options.apiKey || process.env.ORA_SCAN_API_KEY || undefined };
 	options.progress?.(`Auditing ${target} with ora`);
 
 	const streamed = await consumeScanStream(base, target, options);
@@ -101,7 +116,7 @@ async function consumeScanStream(
 	let res: Response;
 	try {
 		res = await fetch(streamUrl(base, target, options), {
-			headers: { accept: "text/event-stream" },
+			headers: { accept: "text/event-stream", ...authHeaders(options.apiKey) },
 			signal: dog.signal,
 		});
 	} catch (cause) {
@@ -115,7 +130,7 @@ async function consumeScanStream(
 		dog.disarm();
 		const wait = res.headers.get("retry-after");
 		throw new AuditApiError(
-			`ora rate limit exceeded${wait ? ` — retry after ${wait}s` : ""} (burst: 10 scans/min/IP; daily: 30 scans + 6 force per 24h)`,
+			`ora rate limit exceeded${wait ? ` — retry after ${wait}s` : ""} (burst: 10 scans/min/IP; daily: 30 scans + 6 force per 24h). An ora-issued scan API key lifts these limits: set ORA_SCAN_API_KEY or pass --api-key.`,
 		);
 	}
 	if (!res.ok || !res.body) {
@@ -252,7 +267,7 @@ async function awaitDeepAnalysis(
 		await pause(every);
 		try {
 			const res = await fetch(scoreUrl, {
-				headers: { accept: "application/json" },
+				headers: { accept: "application/json", ...authHeaders(options.apiKey) },
 				signal: AbortSignal.timeout(15_000),
 			});
 			if (res.ok) latest = (await res.json()) as AuditScoreResult;

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -95,6 +95,15 @@ describe("auditCommand exit codes", () => {
 		);
 	});
 
+	it("threads --api-key to the client", async () => {
+		resolveWith();
+		await run({ apiKey: "sk_live_abc" });
+		expect(vi.mocked(api.performAudit)).toHaveBeenCalledWith(
+			"example.com",
+			expect.objectContaining({ apiKey: "sk_live_abc" }),
+		);
+	});
+
 	it("skips the gate for an auth-gated MCP result (unscored, not failed)", async () => {
 		resolveWith({ mcpAuthRequired: true, score: 0, grade: "F" });
 		expect(await run({ minScore: "70" })).toBe(EXIT.OK);

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -16,6 +16,8 @@ export interface AuditCommandInput {
 	force: boolean;
 	/** User-supplied command that exposes the target and prints a public https URL. */
 	tunnelCmd?: string;
+	/** ora-issued scan API key (--api-key); the client falls back to ORA_SCAN_API_KEY. */
+	apiKey?: string;
 }
 
 /**
@@ -126,6 +128,7 @@ export async function auditCommand(input: AuditCommandInput): Promise<number> {
 			maxAgeSeconds: maxAge.value,
 			force: input.force,
 			ephemeral: useTunnel || undefined,
+			apiKey: input.apiKey?.trim() || undefined,
 		});
 	} catch (cause) {
 		spinner.stop();

--- a/src/contract/types.gen.ts
+++ b/src/contract/types.gen.ts
@@ -188,6 +188,10 @@ export interface components {
       tier?: string;
       /** @description Canonical spec / standard URL this check evaluates against, when one exists. Advisory - the link may change on any release. */
       specUrl?: string;
+      /** @description When the check ran against a specific MCP server within a multi-MCP bundle: that server's kind (currently product | docs | other; advisory - new kinds may appear on any release). Absent for non-MCP checks and single-MCP scans. */
+      mcpKind?: string;
+      /** @description The URL of the MCP server this check scored against. Present only alongside mcpKind. */
+      mcpUrl?: string;
       /** @description What the scan observed for this check */
       details?: string;
       /** @description Concrete fix that would make this check pass. The primary thing to act on. */
@@ -222,6 +226,10 @@ export interface components {
           tier?: string;
           /** @description Canonical spec / standard URL this check evaluates against, when one exists. Advisory - the link may change on any release. */
           specUrl?: string;
+          /** @description When the check ran against a specific MCP server within a multi-MCP bundle: that server's kind (currently product | docs | other; advisory - new kinds may appear on any release). Absent for non-MCP checks and single-MCP scans. */
+          mcpKind?: string;
+          /** @description The URL of the MCP server this check scored against. Present only alongside mcpKind. */
+          mcpUrl?: string;
           /** @description What the scan observed for this check */
           details?: string;
           /** @description Concrete fix that would make this check pass. The primary thing to act on. */
@@ -275,6 +283,10 @@ export interface components {
               tier?: string;
               /** @description Canonical spec / standard URL this check evaluates against, when one exists. Advisory - the link may change on any release. */
               specUrl?: string;
+              /** @description When the check ran against a specific MCP server within a multi-MCP bundle: that server's kind (currently product | docs | other; advisory - new kinds may appear on any release). Absent for non-MCP checks and single-MCP scans. */
+              mcpKind?: string;
+              /** @description The URL of the MCP server this check scored against. Present only alongside mcpKind. */
+              mcpUrl?: string;
               /** @description What the scan observed for this check */
               details?: string;
               /** @description Concrete fix that would make this check pass. The primary thing to act on. */
@@ -307,7 +319,7 @@ export interface components {
        * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.9.0";
+      contractVersion: "1.11.0";
       /**
        * @description Present only when this body is a stored result served by the freshness gate instead of a fresh scan. Absent on a live scan.
        * @enum {boolean}
@@ -325,6 +337,12 @@ export interface components {
        * @enum {string}
        */
       urlKind?: "domain" | "mcp" | "mcp-app" | "ephemeral";
+      /** @description Canonical market category ora classified the domain into (e.g. 'Infrastructure & DevOps'). Advisory; absent when the domain is unclassified. */
+      category?: string;
+      /** @description One-sentence natural-language verdict on the domain's agent-readiness, generated after analysis completes. Advisory; absent on partial results and on older stored results. */
+      agenticSummary?: string;
+      /** @description The URL the scan actually fetched after following redirects. Distinct from `url`, which is the canonical ora.ai deep link for the domain. */
+      finalUrl?: string;
       /** @description Present only when the scan is stuck (partial for over 30 minutes; the worker likely failed) or on the score route's 404 miss - the HTTP request that recovers the score. A plain partial resolves on its own: poll the 202's Location URL instead of re-scanning. */
       nextAction?: {
         /** @enum {string} */
@@ -387,6 +405,10 @@ export interface components {
               tier?: string;
               /** @description Canonical spec / standard URL this check evaluates against, when one exists. Advisory - the link may change on any release. */
               specUrl?: string;
+              /** @description When the check ran against a specific MCP server within a multi-MCP bundle: that server's kind (currently product | docs | other; advisory - new kinds may appear on any release). Absent for non-MCP checks and single-MCP scans. */
+              mcpKind?: string;
+              /** @description The URL of the MCP server this check scored against. Present only alongside mcpKind. */
+              mcpUrl?: string;
               /** @description What the scan observed for this check */
               details?: string;
               /** @description Concrete fix that would make this check pass. The primary thing to act on. */
@@ -419,7 +441,7 @@ export interface components {
        * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.9.0";
+      contractVersion: "1.11.0";
       /** @description Wall-clock duration of the scan that produced this stored result */
       durationMs: number | null;
       /**
@@ -432,6 +454,12 @@ export interface components {
        * @enum {string}
        */
       urlKind?: "domain" | "mcp" | "mcp-app" | "ephemeral";
+      /** @description Canonical market category ora classified the domain into (e.g. 'Infrastructure & DevOps'). Advisory; absent when the domain is unclassified. */
+      category?: string;
+      /** @description One-sentence natural-language verdict on the domain's agent-readiness, generated after analysis completes. Advisory; absent on partial results and on older stored results. */
+      agenticSummary?: string;
+      /** @description The URL the scan actually fetched after following redirects. Distinct from `url`, which is the canonical ora.ai deep link for the domain. */
+      finalUrl?: string;
       /** @description Present only when the scan is stuck (partial for over 30 minutes; the worker likely failed) or on the score route's 404 miss - the HTTP request that recovers the score. A plain partial resolves on its own: poll the 202's Location URL instead of re-scanning. */
       nextAction?: {
         /** @enum {string} */

--- a/src/contract/version.ts
+++ b/src/contract/version.ts
@@ -2,4 +2,4 @@
 // Regenerate: pnpm contract:gen [--url <openapi.json url>]
 
 /** The ora contract version (spec info.version) these types were generated from. */
-export const BUILT_AGAINST = "1.9.0";
+export const BUILT_AGAINST = "1.11.0";

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,11 @@ const audit = defineCommand({
 			description:
 				"Command that exposes a local target and prints its public https URL (e.g. 'ngrok http 3000 --log stdout'); also read from ORA_TUNNEL_CMD. The result is stored as ephemeral",
 		},
+		"api-key": {
+			type: "string",
+			description:
+				"ora-issued scan API key that lifts the scan rate limits; also read from ORA_SCAN_API_KEY",
+		},
 		"show-passing": {
 			type: "boolean",
 			description: "List each passing check individually",
@@ -68,6 +73,7 @@ const audit = defineCommand({
 			maxAge: args["max-age"] as string | undefined,
 			force: Boolean(args.force),
 			tunnelCmd: args["tunnel-cmd"] as string | undefined,
+			apiKey: args["api-key"] as string | undefined,
 		});
 	},
 });
@@ -206,6 +212,7 @@ function helpScreen(): string {
 		`    --max-age <s>    ${d("Accept a cached result up to s seconds old (default 6h)")}`,
 		`    --force          ${d("Bypass the cache and rescan (6/day budget)")}`,
 		`    --tunnel-cmd <c> ${d("Expose a local target via your own tunnel command (e.g. 'ngrok http 3000 --log stdout')")}`,
+		`    --api-key <k>    ${d("ora-issued scan API key that lifts the rate limits; also read from ORA_SCAN_API_KEY")}`,
 		`    --json           ${d("Print the raw ora audit payload as JSON")}`,
 		`    --show-passing   ${d("List each passing check (hidden by default)")}`,
 		`    --show-skipped   ${d("List skipped checks (hidden by default)")}`,


### PR DESCRIPTION
## Motivation

ora's contract 1.10.0 (eralabs-ai/ora#840) introduced **keyed exemption**: an ora-issued scan API key presented as `Authorization: Bearer <key>` exempts the caller from every scan-family rate limit — the daily budget (30/24h execute, 6/24h force) and the 10/min burst guard — on the scan endpoints, including the two this CLI uses. High-volume users currently hit the CLI's `ora rate limit exceeded` error with no way through.

## What this does

- **`src/api/audit.ts`** — `AuditOptions.apiKey`, resolved once in `performAudit` (explicit option → `ORA_SCAN_API_KEY` env → keyless) and attached as a bearer header to **both** HTTP calls: the `GET /api/scan/stream` request and the `GET /api/score/{domain}` deep-analysis poll (the poll target is rate limited too — a keyed scan whose polls went keyless would throttle exactly the callers keys exist for). The 429 message now points at the key.
- **`src/commands/audit.ts` / `src/main.ts`** — `--api-key <k>` on `ax audit`, shown in both the generated and hand-rolled help.
- **`src/contract/`** — regenerated against production: `BUILT_AGAINST` 1.9.0 → **1.11.0** (additive `mcpKind`/`mcpUrl` check fields came along).
- **README / `.env.example`** — document `ORA_SCAN_API_KEY`; keys are issued manually by ora, no self-serve.

Not touched: the platform `ORA_API_KEY` (different credential, different API) and retry logic.

## Safety

The server degrades a missing/unrecognized bearer to keyless rather than 401 (MCP clients send unrelated bearers on the same header), so this is purely additive — keyless behavior is byte-identical. An empty env value (unset CI variable expanding to `""`) counts as absent.

## Verification

- TDD red-green: 6 new API tests (bearer on stream, env fallback, flag-over-env precedence, empty-env keyless, bearer on poll, 429 hint) + command threading test, all watched failing first.
- 85/85 tests pass, typecheck clean, build succeeds (the one biome warning pre-dates this change).
- End-to-end against a header-sniffing mock server: the built binary sent no header keyless and `Bearer <flag key>` with both env and flag set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)