### PR TITLE
feat(deep-journey): partner API key tier — free-text --task, 1000/24h allowance, stream-to-poll fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,4 +18,10 @@ ORA_PLATFORM_URL=https://api.agentfront.sh
 # ora-issued scan API key for `ax audit` (same as --api-key): exempts the
 # caller from the scan rate limits (30/day + 6 force/day + 10/min burst).
 # Issued manually by ora — no self-serve signup. Leave unset for normal use.
+# `ax deep-journey` also accepts it as a partner-key fallback.
 # ORA_SCAN_API_KEY=
+
+# ora-issued partner API key for `ax deep-journey` (same as --api-key):
+# unlocks free-text --task runs and the 1000 runs/24h keyed allowance
+# (no per-target cap, no burst guard). Issued manually by ora.
+# ORA_PARTNER_API_KEY=

--- a/README.md
+++ b/README.md
@@ -87,14 +87,15 @@ ax audit localhost:3000 --tunnel-cmd 'ngrok http 3000 --log stdout'
 ## deep-journey
 
 ```
-ax deep-journey <url> [--intent id] [--agent id] [--no-stream] [--json]
+ax deep-journey <url> [--intent id | --task text] [--agent id] [--api-key k] [--no-stream] [--json]
 ```
 
 ```
 ax deep-journey stripe.com --intent pricing
+ax deep-journey zapier.com --task "Find how to build a Slack → Sheets zap"   # needs a partner key
 ```
 
-Runs a real AI agent at a site on a curated task through ora's **public** journey API — no key, no workspace. The agent's trajectory streams live as progress lines; the terminal output is ora's verdict, the billable step count, and the generated insight:
+Runs a real AI agent at a site through ora's **public** journey API — no key, no workspace needed for curated tasks. The agent's trajectory streams live as progress lines; the terminal output is ora's verdict, the billable step count, and the generated insight:
 
 ```
   ✓ task satisfied  stripe.com
@@ -108,11 +109,17 @@ Runs a real AI agent at a site on a curated task through ora's **public** journe
   For the 4-layer readiness audit, run: ax audit stripe.com
 ```
 
-Curated intents only (`pricing`, `signup`, `api-docs`, `get started`, `support`, …) — list them with `GET https://ora.ai/api/journey/intents`, and the accepted agents with `GET https://ora.ai/api/journey/agents`. The public caps are 5 runs per rolling 24h per target and 10 runs per 24h per IP; a target at its cap answers with the most recent stored run (`rate_limited: true`) instead of an error, so repeat CI invocations are cheap. Verdict and step count come from ora's contract as-is — the CLI never re-judges a run.
+Anonymous callers run curated intents (`pricing`, `signup`, `api-docs`, `get started`, `support`, …) — list them with `GET https://ora.ai/api/journey/intents`, and the accepted agents with `GET https://ora.ai/api/journey/agents`. The public caps are 100 runs per rolling 24h per target and 200 runs per 24h per IP; a target at its cap answers with the most recent stored run (`rate_limited: true`) instead of an error, so repeat CI invocations are cheap. Verdict and step count come from ora's contract as-is — the CLI never re-judges a run.
+
+**Keyed tier:** an ora-issued partner API key (`--api-key`, or `ORA_PARTNER_API_KEY` / `ORA_SCAN_API_KEY` in the environment) unlocks `--task` — a free-text task of 4–300 characters that replaces the curated intent — and moves the caller to an allowance of 1000 runs per rolling 24h per key with no per-target cap and no burst guard. Keys are issued manually by ora (no self-serve signup). A wrong or unrecognized key with a *curated* intent silently degrades to the anonymous tier; `--task` without a recognized key is an error.
+
+If the live stream goes quiet (no frames for 120s) the CLI does not abandon the run — it switches to polling the run detail until the server reports a terminal state.
 
 | Flag | Effect |
 |---|---|
 | `--intent <id>` | Curated task id (server default when omitted) |
+| `--task <text>` | Free-text task — needs a partner API key; mutually exclusive with `--intent` |
+| `--api-key <k>` | ora partner API key; also read from `ORA_PARTNER_API_KEY` (then `ORA_SCAN_API_KEY`) |
 | `--agent <id>` | Agent from the public roster (default: ora's pick) |
 | `--no-stream` | Poll for the result instead of streaming the trajectory |
 | `--json` | Print the terminal run detail (verdict, step_count, result) as JSON |
@@ -233,7 +240,8 @@ A `.env` in the working directory is read on startup — copy `.env.example` and
 | `ORA_API_URL` | audit, deep-journey, skill | `https://ora.ai` | Public API base (no auth) |
 | `ORA_PLATFORM_URL` | journey | `https://api.agentfront.sh` | Authenticated platform API base |
 | `ORA_API_KEY` | journey | — (required) | Secret key (`ora_sk_…`), exchanged for a short-lived bearer token |
-| `ORA_SCAN_API_KEY` | audit | — (optional) | ora-issued scan API key; lifts every scan rate limit (issued manually by ora) |
+| `ORA_SCAN_API_KEY` | audit, deep-journey | — (optional) | ora-issued scan API key; lifts every scan rate limit (issued manually by ora). deep-journey accepts it as a partner-key fallback |
+| `ORA_PARTNER_API_KEY` | deep-journey | — (optional) | ora-issued partner API key; unlocks `--task` and the 1000/24h keyed allowance |
 
 ## Contract versioning
 

--- a/src/api/deep-journey.test.ts
+++ b/src/api/deep-journey.test.ts
@@ -222,6 +222,131 @@ describe("performDeepJourney", () => {
 	});
 });
 
+describe("performDeepJourney - keyed tier", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+	});
+
+	const succeededMock = () =>
+		journeyMock({
+			trigger: asJson({ ...RECORD, status: "succeeded" }, 201, {
+				"x-ratelimit-limit": "1000",
+				"x-ratelimit-remaining": "999",
+			}),
+		});
+
+	const triggerInit = (mock: ReturnType<typeof vi.fn>) => {
+		const call = mock.mock.calls.find(
+			([url, init]) =>
+				String(url).endsWith("/api/journey/runs") &&
+				(init as { method?: string } | undefined)?.method === "POST",
+		);
+		return call?.[1] as { headers: Record<string, string>; body: string };
+	};
+
+	it("sends the partner key as a bearer token on the trigger POST", async () => {
+		const mock = succeededMock();
+		vi.stubGlobal("fetch", mock);
+
+		await performDeepJourney("vercel.com", { ...OPTIONS, apiKey: "pk_live_demo_0123456789" });
+		expect(triggerInit(mock).headers.authorization).toBe("Bearer pk_live_demo_0123456789");
+	});
+
+	it("sends no authorization header without a key", async () => {
+		// Blank out any ambient keys so this asserts the true keyless path.
+		vi.stubEnv("ORA_PARTNER_API_KEY", "");
+		vi.stubEnv("ORA_SCAN_API_KEY", "");
+		const mock = succeededMock();
+		vi.stubGlobal("fetch", mock);
+
+		await performDeepJourney("vercel.com", OPTIONS);
+		expect(triggerInit(mock).headers.authorization).toBeUndefined();
+	});
+
+	it("reads the key from ORA_PARTNER_API_KEY when no explicit option is given", async () => {
+		vi.stubEnv("ORA_PARTNER_API_KEY", "pk_live_from_env_0123456789");
+		const mock = succeededMock();
+		vi.stubGlobal("fetch", mock);
+
+		await performDeepJourney("vercel.com", OPTIONS);
+		expect(triggerInit(mock).headers.authorization).toBe("Bearer pk_live_from_env_0123456789");
+	});
+
+	it("runs a free-text task through the custom intent arm", async () => {
+		const mock = succeededMock();
+		vi.stubGlobal("fetch", mock);
+
+		await performDeepJourney("vercel.com", {
+			...OPTIONS,
+			intentId: undefined,
+			task: "Find how to export a project to GitHub",
+			apiKey: "pk_live_demo_0123456789",
+		});
+
+		const body = JSON.parse(triggerInit(mock).body) as { intent: Record<string, unknown> };
+		expect(body.intent).toEqual({
+			custom: "Find how to export a project to GitHub",
+			domain: "vercel.com",
+		});
+	});
+
+	it("maps the custom-intent 401 to an actionable partner-key error", async () => {
+		vi.stubGlobal(
+			"fetch",
+			journeyMock({
+				trigger: asJson(
+					{ error: "Custom intents require a partner API key", code: "CUSTOM_INTENT_REQUIRES_KEY" },
+					401,
+				),
+			}),
+		);
+
+		await expect(
+			performDeepJourney("vercel.com", { ...OPTIONS, intentId: undefined, task: "Find the docs" }),
+		).rejects.toThrow(/ORA_PARTNER_API_KEY|--api-key/);
+	});
+
+	it("falls back to polling when the stream goes quiet instead of abandoning the run", async () => {
+		// The stream opens but never emits a frame (yesterday's production failure
+		// mode); the run itself keeps executing server-side. The client must
+		// switch to polling the detail rather than throwing away a paid run.
+		const hangingStream = (signal: AbortSignal | undefined): Response =>
+			new Response(
+				new ReadableStream({
+					start(controller) {
+						signal?.addEventListener("abort", () =>
+							controller.error(Object.assign(new Error("aborted"), { name: "AbortError" })),
+						);
+					},
+				}),
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+
+		const inner = journeyMock({
+			details: [{ ...(realDetail as object), status: "running", result: undefined }, realDetail],
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (url: string | URL, init?: { method?: string; signal?: AbortSignal }) => {
+				if (String(url).includes("/stream")) return hangingStream(init?.signal);
+				return inner(url, init);
+			}),
+		);
+
+		const lines: string[] = [];
+		const outcome = await performDeepJourney("vercel.com", {
+			...OPTIONS,
+			idleMs: 50,
+			pollEveryMs: 1,
+			progress: (line) => lines.push(line),
+		});
+
+		expect(outcome.detail.status).toBe("succeeded");
+		expect(lines.some((line) => /polling/.test(line))).toBe(true);
+	});
+});
+
 describe("fetchJourneyAgents", () => {
 	afterEach(() => vi.unstubAllGlobals());
 

--- a/src/api/deep-journey.ts
+++ b/src/api/deep-journey.ts
@@ -10,8 +10,10 @@ import { errorBodyText, pause, watchdog } from "./shared";
 
 // Client for ora's public deep-journey API (/api/journey/*): a real AI agent
 // attempts a curated task against a domain while ora records the trajectory.
-// Unauthenticated by design (same posture as audit.ts) - the public surface is
-// rate-limited per target and per caller, not keyed.
+// Anonymous by default (same posture as audit.ts) - the public surface is
+// rate-limited per target and per caller. A partner API key (optional)
+// unlocks the keyed tier: free-text tasks and a per-key allowance instead of
+// the per-IP one.
 //
 // Thin client: every field (verdict, step_count, insight, trajectory) comes
 // from the versioned journey contract as-is; nothing here re-derives judgement.
@@ -56,6 +58,21 @@ export interface RunAllowance {
 export interface DeepJourneyOptions {
 	/** Curated intent id; the server default when omitted. */
 	intentId?: string;
+	/**
+	 * Free-text task (the keyed custom arm, 4-300 chars server-side). Needs a
+	 * partner API key; mutually exclusive with `intentId` (the command layer
+	 * enforces the exclusivity, this client just sends whichever arm is set).
+	 */
+	task?: string;
+	/**
+	 * ora-issued partner API key, sent as `Authorization: Bearer`. Unlocks
+	 * free-text tasks and moves the caller to the 1000/24h per-key allowance
+	 * (no per-target cap, no burst guard). Falls back to $ORA_PARTNER_API_KEY,
+	 * then $ORA_SCAN_API_KEY (the shared partner registry serves both
+	 * surfaces). Safe to send a wrong key with a curated intent - the server
+	 * silently degrades to the keyless tier.
+	 */
+	apiKey?: string;
 	harness: string;
 	model: string;
 	/** Receives one-line progress updates while the run streams/polls. */
@@ -143,11 +160,16 @@ async function triggerRun(
 	target: string,
 	options: DeepJourneyOptions,
 ): Promise<TriggeredRun> {
+	// The custom arm ({custom, domain}) and the curated arm ({intent_id?,
+	// domain}) are mutually exclusive server-side (strict union); whichever the
+	// caller set is the one sent.
 	const body: Record<string, unknown> = {
-		intent: {
-			...(options.intentId ? { intent_id: options.intentId } : {}),
-			domain: target,
-		},
+		intent: options.task
+			? { custom: options.task, domain: target }
+			: {
+					...(options.intentId ? { intent_id: options.intentId } : {}),
+					domain: target,
+				},
 		harness: options.harness,
 		model: options.model,
 	};
@@ -156,7 +178,11 @@ async function triggerRun(
 	try {
 		res = await fetch(`${base}/api/journey/runs`, {
 			method: "POST",
-			headers: { "content-type": "application/json", accept: "application/json" },
+			headers: {
+				"content-type": "application/json",
+				accept: "application/json",
+				...(options.apiKey ? { authorization: `Bearer ${options.apiKey}` } : {}),
+			},
 			body: JSON.stringify(body),
 			signal: AbortSignal.timeout(30_000),
 		});
@@ -165,10 +191,20 @@ async function triggerRun(
 		throw new DeepJourneyApiError(`ora journey request failed: ${detail}`);
 	}
 
+	if (res.status === 401) {
+		// The capability 401: free text needs a recognized partner key. (A
+		// curated body never 401s - a bad key silently degrades to keyless.)
+		throw new DeepJourneyApiError(
+			"free-text tasks need an ora partner API key — set ORA_PARTNER_API_KEY or pass --api-key (keys are issued by ora on request)",
+		);
+	}
 	if (res.status === 429) {
 		const wait = res.headers.get("retry-after");
+		const caps = options.apiKey
+			? "keyed allowance: 1000 runs per 24h per key"
+			: "burst: 20/min/IP; daily: 200 runs per 24h per IP — an ora partner API key raises this to 1000/24h per key: set ORA_PARTNER_API_KEY or pass --api-key";
 		throw new DeepJourneyApiError(
-			`ora journey caller limit exceeded${wait ? ` — retry after ${formatWait(Number(wait) * 1000)}` : ""} (burst: 20/min/IP; daily: 10 runs per 24h per IP)`,
+			`ora journey caller limit exceeded${wait ? ` — retry after ${formatWait(Number(wait) * 1000)}` : ""} (${caps})`,
 		);
 	}
 	if (res.status === 503) {
@@ -336,6 +372,15 @@ export async function performDeepJourney(
 	options: DeepJourneyOptions,
 ): Promise<DeepJourneyOutcome> {
 	const base = apiBase(options.baseUrl);
+	// `||` not `??`: an empty --api-key should fall through to the env chain.
+	options = {
+		...options,
+		apiKey:
+			options.apiKey ||
+			process.env.ORA_PARTNER_API_KEY ||
+			process.env.ORA_SCAN_API_KEY ||
+			undefined,
+	};
 
 	const triggered = await triggerRun(base, target, options);
 	const { record } = triggered;
@@ -348,12 +393,22 @@ export async function performDeepJourney(
 	// live streaming attaches to it the same way a fresh run does.
 	let engineError: string | undefined;
 	if (!options.noStream && record.status === "running") {
-		const streamed = await followJourneyStream(base, record.stream_url, options);
-		// A terminal `error` frame means the run failed - NOT a client failure.
-		// Fall through to the detail so a failed run resolves the same way it
-		// does under --no-stream (status "failed" -> the caller's run-failed
-		// path), keeping exit codes consistent across both modes.
-		engineError = streamed.errorMessage;
+		try {
+			const streamed = await followJourneyStream(base, record.stream_url, options);
+			// A terminal `error` frame means the run failed - NOT a client failure.
+			// Fall through to the detail so a failed run resolves the same way it
+			// does under --no-stream (status "failed" -> the caller's run-failed
+			// path), keeping exit codes consistent across both modes.
+			engineError = streamed.errorMessage;
+		} catch {
+			// The stream is a live view, not the run: a quiet or broken SSE (idle
+			// timeout, transport reset) must never abandon a run that is still
+			// executing - and still billing - server-side. Degrade to polling the
+			// detail; if the run really is stuck, the still-running guard below
+			// reports it after the poll budget.
+			options.progress?.("stream went quiet — switching to polling");
+			await awaitByPolling(base, record.id, options);
+		}
 	} else if (options.noStream && record.status === "running") {
 		await awaitByPolling(base, record.id, options);
 	}

--- a/src/commands/deep-journey.test.ts
+++ b/src/commands/deep-journey.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { deepJourneyCommand, EXIT } from "./deep-journey";
+
+// Command-layer contract for the keyed tier: flag exclusivity and the
+// fail-fast key check happen HERE, before any network call - the API client
+// stays a thin sender. The API layer itself is covered in
+// src/api/deep-journey.test.ts; everything below mocks it out.
+
+vi.mock("../api/deep-journey", async (importOriginal) => {
+	const real = await importOriginal<typeof import("../api/deep-journey")>();
+	return {
+		...real,
+		fetchJourneyIntents: vi.fn(async () => ({
+			intents: [{ id: "pricing", label: "Pricing", hint: "find pricing", template: "" }],
+			defaultId: "pricing",
+		})),
+		fetchJourneyAgents: vi.fn(async () => ({
+			agents: [
+				{
+					id: "cas-haiku",
+					label: "Claude Code",
+					variant: "Haiku 4.5",
+					harness: "claude-agent-sdk",
+					model: "claude-haiku-4-5",
+				},
+			],
+			defaultId: "cas-haiku",
+		})),
+		performDeepJourney: vi.fn(async () => ({
+			record: { id: "run_1", status: "succeeded" },
+			cached: false,
+			allowance: {},
+			detail: { id: "run_1", status: "succeeded", domain: "zapier.com", contractVersion: "1.15.0" },
+		})),
+	};
+});
+
+import { fetchJourneyIntents, performDeepJourney } from "../api/deep-journey";
+
+const BASE = { url: "zapier.com", json: true, noStream: false };
+
+describe("deepJourneyCommand - keyed tier flags", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubEnv("ORA_PARTNER_API_KEY", "");
+		vi.stubEnv("ORA_SCAN_API_KEY", "");
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "log").mockImplementation(() => {});
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+	});
+
+	it("rejects --task combined with --intent as a usage error", async () => {
+		const code = await deepJourneyCommand({
+			...BASE,
+			task: "Find the pricing page",
+			intent: "pricing",
+			apiKey: "pk_live_demo_0123456789",
+		});
+		expect(code).toBe(EXIT.USAGE);
+		expect(performDeepJourney).not.toHaveBeenCalled();
+	});
+
+	it("fails fast on --task without any partner key", async () => {
+		const code = await deepJourneyCommand({ ...BASE, task: "Find the pricing page" });
+		expect(code).toBe(EXIT.USAGE);
+		expect(performDeepJourney).not.toHaveBeenCalled();
+	});
+
+	it("runs a --task journey without resolving curated intents", async () => {
+		const code = await deepJourneyCommand({
+			...BASE,
+			task: "Find how to build a Slack to Sheets zap",
+			apiKey: "pk_live_demo_0123456789",
+		});
+		expect(code).toBe(EXIT.OK);
+		expect(fetchJourneyIntents).not.toHaveBeenCalled();
+		expect(performDeepJourney).toHaveBeenCalledWith(
+			"zapier.com",
+			expect.objectContaining({
+				task: "Find how to build a Slack to Sheets zap",
+				intentId: undefined,
+				apiKey: "pk_live_demo_0123456789",
+			}),
+		);
+	});
+
+	it("accepts a key from ORA_PARTNER_API_KEY for --task runs", async () => {
+		vi.stubEnv("ORA_PARTNER_API_KEY", "pk_live_from_env_0123456789");
+		const code = await deepJourneyCommand({ ...BASE, task: "Find the pricing page" });
+		expect(code).toBe(EXIT.OK);
+		expect(performDeepJourney).toHaveBeenCalled();
+	});
+});

--- a/src/commands/deep-journey.ts
+++ b/src/commands/deep-journey.ts
@@ -17,14 +17,20 @@ import { spinner } from "../ui/spinner";
 
 export const EXIT = { OK: 0, RUN_FAILED: 1, USAGE: 2, API: 3 } as const;
 
-// The documented public caps, shown up front so a CI author can budget runs
-// before spending one. The live remaining allowance comes from the response
-// headers after the trigger.
-const CAPS_LINE = "public caps: 5 runs/24h per target · 10 runs/24h per IP";
+// The documented caps, shown up front so a CI author can budget runs before
+// spending one. The live remaining allowance comes from the response headers
+// after the trigger. One line per tier - which one the caller is on is known
+// locally (key present or not).
+const CAPS_LINE = "public caps: 100 runs/24h per target · 200 runs/24h per IP";
+const KEYED_CAPS_LINE = "keyed caps: 1000 runs/24h per key · no per-target cap";
 
 export interface DeepJourneyCommandInput {
 	url: string;
 	intent?: string;
+	/** Free-text task (keyed tier); mutually exclusive with `intent`. */
+	task?: string;
+	/** Partner API key (--api-key); falls back to $ORA_PARTNER_API_KEY, then $ORA_SCAN_API_KEY. */
+	apiKey?: string;
 	agent?: string;
 	json: boolean;
 	noStream: boolean;
@@ -97,21 +103,47 @@ export async function deepJourneyCommand(input: DeepJourneyCommandInput): Promis
 
 	const interactive = !input.json && process.stderr.isTTY;
 
+	// Tier resolution, before any network call: the two intent arms are
+	// mutually exclusive, and a free-text task without a key would only 401
+	// server-side - fail fast with the fix instead of spending a request.
+	const task = input.task?.trim() || undefined;
+	const apiKey =
+		input.apiKey || process.env.ORA_PARTNER_API_KEY || process.env.ORA_SCAN_API_KEY || undefined;
+	if (task && input.intent !== undefined) {
+		console.error(
+			"ax deep-journey: --task and --intent are mutually exclusive — a free-text task replaces the curated intent",
+		);
+		return EXIT.USAGE;
+	}
+	if (task && !apiKey) {
+		console.error(
+			"ax deep-journey: --task needs an ora partner API key — set ORA_PARTNER_API_KEY or pass --api-key (keys are issued by ora on request)",
+		);
+		return EXIT.USAGE;
+	}
+
 	// Resolve the intent and agent against the live rosters (both static,
-	// cached routes) so a typo fails with the menu instead of a bare 400.
+	// cached routes) so a typo fails with the menu instead of a bare 400. A
+	// free-text task skips the intent roster entirely - the server takes the
+	// text as-is (anchored to the target) instead of a template id.
 	let intentId = input.intent;
 	let agent: JourneyAgentOption;
 	try {
-		const [intents, agents] = await Promise.all([fetchJourneyIntents(), fetchJourneyAgents()]);
-		if (intentId === undefined) {
-			intentId = intents.defaultId;
-		} else if (!intents.intents.some((option) => option.id === intentId)) {
-			console.error(
-				`ax deep-journey: unknown intent "${intentId}". Available intents:\n${intents.intents
-					.map((option) => `  ${option.id.padEnd(12)} ${option.hint}`)
-					.join("\n")}`,
-			);
-			return EXIT.USAGE;
+		const [intents, agents] = await Promise.all([
+			task ? undefined : fetchJourneyIntents(),
+			fetchJourneyAgents(),
+		]);
+		if (intents) {
+			if (intentId === undefined) {
+				intentId = intents.defaultId;
+			} else if (!intents.intents.some((option) => option.id === intentId)) {
+				console.error(
+					`ax deep-journey: unknown intent "${intentId}". Available intents:\n${intents.intents
+						.map((option) => `  ${option.id.padEnd(12)} ${option.hint}`)
+						.join("\n")}`,
+				);
+				return EXIT.USAGE;
+			}
 		}
 		const wantedAgent = input.agent ?? agents.defaultId;
 		const found = agents.agents.find((option) => option.id === wantedAgent);
@@ -129,14 +161,18 @@ export async function deepJourneyCommand(input: DeepJourneyCommandInput): Promis
 	}
 
 	if (!input.json) {
-		console.error(pc.dim(CAPS_LINE));
+		console.error(pc.dim(apiKey ? KEYED_CAPS_LINE : CAPS_LINE));
 	}
-	if (interactive) spinner.start(`Sending ${agentLine(agent)} to ${target} (${intentId})`);
+	if (interactive) {
+		spinner.start(`Sending ${agentLine(agent)} to ${target} (${task ? `"${task}"` : intentId})`);
+	}
 
 	let outcome: DeepJourneyOutcome;
 	try {
 		outcome = await performDeepJourney(target, {
-			intentId,
+			intentId: task ? undefined : intentId,
+			task,
+			apiKey,
 			harness: agent.harness,
 			model: agent.model,
 			noStream: input.noStream,

--- a/src/contract/types.gen.ts
+++ b/src/contract/types.gen.ts
@@ -6,6 +6,11 @@
  */
 
 
+/** OneOf type helpers */
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
+type OneOf<T extends any[]> = T extends [infer Only] ? Only : T extends [infer A, infer B, ...infer Rest] ? OneOf<[XOR<A, B>, ...Rest]> : never;
+
 export interface paths {
   "/api/scan": {
     /**
@@ -41,6 +46,13 @@ export interface paths {
      * @description Returns an SVG badge showing the domain's ora score and grade. Embed in READMEs or websites. Cached for 1 hour.
      */
     get: operations["getBadge"];
+  };
+  "/api/checks": {
+    /**
+     * Get the complete catalog of scanner checks
+     * @description Returns every check the ora scanner can run - stable id, scored layer, max score, applicability, eligible scan kinds, tier, maturity, and fix guidance per check, plus the four scored layers with their weights. Check ids are stable: gate CI on an explicit id list, not on tiers (the required set can grow on a minor version). The document is static and byte-stable between check-set changes, so diffing it detects catalog updates. No parameters. Sends Access-Control-Allow-Origin: * and is CDN-cached for 1 hour. Rate limited to 60 requests per minute per IP - returns 429 with a Retry-After header if exceeded.
+     */
+    get: operations["listChecks"];
   };
   "/api/discover": {
     /**
@@ -122,7 +134,7 @@ export interface paths {
   "/api/journey/runs": {
     /**
      * Run an agent journey against a domain
-     * @description Triggers a real agent run: an AI agent (harness + model) attempts a curated task (an intent) against the given domain, and ora records the trajectory and derives insights. Two-step flow: this endpoint returns fast with a run record whose `stream_url` serves the live trajectory as Server-Sent Events; poll GET /api/journey/runs/{id} instead if you do not want the stream. Only curated intents run publicly (see GET /api/journey/intents) - the server derives the actual agent prompt from the intent id, so no free-text prompt can reach the engine. Only publicly runnable agents are accepted (see GET /api/journey/agents). Unknown body fields are rejected (strict schema). Rate limited three ways: a 20-per-minute burst cap per IP; a per-target cap of 5 runs per rolling 24h per (domain, intent, harness, model) - when a target is over the cap the response is HTTP 200 with the most recent stored run for that target (`rate_limited: true`) plus Retry-After, the freshness analog: a denied trigger still returns the newest result and consumes nothing; and a durable per-caller cap of 10 runs per rolling 24h per IP - exceeded, that one is a real 429 with `retry_after_ms` (there is no cached result to serve for a caller). Successful and capped responses carry X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset headers for the per-target window. Note: journey insights use the 5-layer journey taxonomy (discovery, identity, access, payments, experience), deliberately distinct from the 4 scoring layers of the audit report (POST /api/scan) - never map between the two.
+     * @description Triggers a real agent run: an AI agent (harness + model) attempts a task (an intent) against the given domain, and ora records the trajectory and derives insights. Two-step flow: this endpoint returns fast with a run record whose `stream_url` serves the live trajectory as Server-Sent Events; poll GET /api/journey/runs/{id} instead if you do not want the stream. Two caller tiers. Anonymous: curated intents only (see GET /api/journey/intents) - the server derives the actual agent prompt from the intent id, so no free-text prompt can reach the engine. Keyed: a caller presenting an ora-issued partner API key ('Authorization: Bearer <key>', issued manually - contact ora) may instead send bounded free text (`intent.custom`, 4 to 300 characters, with `intent.domain` required), which the server anchors to the requested domain before dispatch and echoes back on the 201. Free text without a recognized key is a 401 with code CUSTOM_INTENT_REQUIRES_KEY; a curated body with a missing or unrecognized key is never an error and simply runs on the anonymous tier. The keyed free-text tier is also reachable from the ora CLI (ax deep-journey --task, v0.5+). Only publicly runnable agents are accepted (see GET /api/journey/agents). Unknown body fields are rejected (strict schema). Anonymous rate limits, three ways: a 20-per-minute burst cap per IP; a per-target cap of 100 runs per rolling 24h per (domain, intent, harness, model) - when a target is over the cap the response is HTTP 200 with the most recent stored run for that target (`rate_limited: true`) plus Retry-After, the freshness analog: a denied trigger still returns the newest result and consumes nothing; and a durable per-caller cap of 200 runs per rolling 24h per IP - exceeded, that one is a real 429 with `retry_after_ms` (there is no cached result to serve for a caller). Keyed rate limit, one way: 1000 runs per rolling 24h per key, exhaustion being the same 429 with `retry_after_ms`. A keyed caller skips both the burst cap and the per-target cap - free text fragments the target key, so a per-target window over it could never fill. Successful and capped responses carry X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset headers describing exactly one window: the per-target window on an anonymous response, the per-key caller window on a keyed one. Note: journey insights use the 5-layer journey taxonomy (discovery, identity, access, payments, experience), deliberately distinct from the 4 scoring layers of the audit report (POST /api/scan) - never map between the two.
      */
     post: operations["createJourneyRun"];
   };
@@ -296,7 +308,7 @@ export interface components {
             })[];
         })[];
       /** @description Actionable (fail/warning) checks ranked by ora: non-bonus first, then estimated uplift descending, capped at 6. Render verbatim - do not re-rank. */
-      topFixes: {
+      topFixes: ({
           /** @description Check id of the fix (stable) - matches a check in layers */
           id: string;
           /** @description Id of the layer the check belongs to */
@@ -309,7 +321,11 @@ export interface components {
           bonus: boolean;
           /** @description Concrete fix that would make this check pass */
           recommendation?: string;
-        }[];
+          /** @description When the check ran against a specific MCP server within a multi-MCP bundle: that server's kind (currently product | docs | other; advisory - new kinds may appear on any release). Absent for non-MCP checks and single-MCP scans. */
+          mcpKind?: string;
+          /** @description The URL of the MCP server this check scored against. Present only alongside mcpKind. */
+          mcpUrl?: string;
+        })[];
       /** @description Canonical ora.ai deep link for the domain */
       url: string;
       generatedAt: string;
@@ -319,7 +335,7 @@ export interface components {
        * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.11.0";
+      contractVersion: "1.15.0";
       /**
        * @description Present only when this body is a stored result served by the freshness gate instead of a fresh scan. Absent on a live scan.
        * @enum {boolean}
@@ -418,7 +434,7 @@ export interface components {
             })[];
         })[];
       /** @description Actionable (fail/warning) checks ranked by ora: non-bonus first, then estimated uplift descending, capped at 6. Render verbatim - do not re-rank. */
-      topFixes: {
+      topFixes: ({
           /** @description Check id of the fix (stable) - matches a check in layers */
           id: string;
           /** @description Id of the layer the check belongs to */
@@ -431,7 +447,11 @@ export interface components {
           bonus: boolean;
           /** @description Concrete fix that would make this check pass */
           recommendation?: string;
-        }[];
+          /** @description When the check ran against a specific MCP server within a multi-MCP bundle: that server's kind (currently product | docs | other; advisory - new kinds may appear on any release). Absent for non-MCP checks and single-MCP scans. */
+          mcpKind?: string;
+          /** @description The URL of the MCP server this check scored against. Present only alongside mcpKind. */
+          mcpUrl?: string;
+        })[];
       /** @description Canonical ora.ai deep link for the domain */
       url: string;
       generatedAt: string;
@@ -441,7 +461,7 @@ export interface components {
        * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.11.0";
+      contractVersion: "1.15.0";
       /** @description Wall-clock duration of the scan that produced this stored result */
       durationMs: number | null;
       /**
@@ -479,6 +499,92 @@ export interface components {
         [key: string]: unknown;
       } | null;
     };
+    /** @description The complete catalog of scanner checks. Stability classes: every field's shape and presence rule is stable within a major version; check and layer ids are identity, so removing, renaming, or changing the meaning of one is a major version change; every other value (scores, weights, layer assignments, applicability, tiers, maturity, prose) is advisory and may change on a minor version, with score-relevant changes recorded in the contract changelog. Gate CI on an explicit list of check ids. */
+    CheckCatalog: {
+      /**
+       * @description The contract version this catalog conforms to - identical to the OpenAPI info.version and the MCP server version. SemVer: a major means a stable field or a check or layer id was removed, renamed, or changed meaning. The full versioning policy is published in the API description at /api/openapi.json.
+       * @enum {string}
+       */
+      contractVersion: "1.15.0";
+      /** @description The four scored layers in scoring order, with display name and current weight. */
+      layers: {
+          /** @description Stable layer id: discovery, accessibility, usability, or payments. Removing or renaming a layer id is a major version change. Note one intentional divergence: the id 'accessibility' carries the display name 'Access'. */
+          id: string;
+          /** @description Display name for the layer. Advisory: it may change on a minor version. */
+          name: string;
+          /** @description The layer's weight in the overall 0-100 score. Weights sum to 100 across the four layers. Advisory: a rebalance lands on a minor version with a changelog entry. */
+          weight: number;
+        }[];
+      /** @description All catalogued checks. Array order is not contractual: key by id. */
+      checks: ({
+          /** @description Stable check identifier, safe to persist and to gate CI on. Removing, renaming, or changing the meaning of an id is a major version change. */
+          id: string;
+          /** @description Human-readable check title. Advisory display prose. */
+          name: string;
+          /** @description What the check verifies and why it matters to agents. Advisory display prose. */
+          description: string;
+          /** @description The check's scored layer id, always one of the ids in layers[]. A check can move to a different layer on a minor version with a changelog entry. */
+          layer: string;
+          /** @description The check's maximum contribution to its layer. Do not sum maxScore into a score denominator: emerging checks sit outside scoring, a bonus counts only the points it earned (it can raise a score, never lower it), and N/A results drop out. Rebalances land on a minor version with a changelog entry. */
+          maxScore: number;
+          /** @description Always present. A bonus check can only add score: a site that lacks the surface is never penalised for failing it. */
+          bonus: boolean;
+          /** @description The check's declared applicability rule. One of: all | domain-only | mcp | mcp-app | api. A value change lands on a minor version with a changelog entry. */
+          applicability: string;
+          /** @description Present only when applicability is 'api'. One of: rest | graphql | either - the API surface the check evaluates. */
+          protocol?: string;
+          /** @description The scan kinds this check can run for - a subset of: domain | mcp | mcp-app. Eligibility, not a guarantee: MCP checks run once per MCP surface detected on the target and report N/A when none is present, and 'api' checks report N/A when the target has no REST or GraphQL surface. */
+          appliesTo: string[];
+          /** @description One of: required | recommended | emerging. Advisory: the required set may grow on a minor version, and every tier change carries a changelog entry. Gate CI on explicit check ids, not on tiers. */
+          tier: string;
+          /** @description One of: verified | emerging. Emerging checks are shown on score pages but excluded from scoring, so do not treat them as score-affecting when selecting checks. */
+          maturity: string;
+          /** @description Always present. True when the check's underlying spec is a draft or emerging standard. */
+          draft: boolean;
+          /** @description Canonical spec or standard URL. Omitted when the check has none. */
+          specUrl?: string;
+          /** @description Generic, target-independent fix guidance. Omitted for the few checks that have none. */
+          recommendation?: string;
+        })[];
+    };
+    CatalogCheck: {
+      /** @description Stable check identifier, safe to persist and to gate CI on. Removing, renaming, or changing the meaning of an id is a major version change. */
+      id: string;
+      /** @description Human-readable check title. Advisory display prose. */
+      name: string;
+      /** @description What the check verifies and why it matters to agents. Advisory display prose. */
+      description: string;
+      /** @description The check's scored layer id, always one of the ids in layers[]. A check can move to a different layer on a minor version with a changelog entry. */
+      layer: string;
+      /** @description The check's maximum contribution to its layer. Do not sum maxScore into a score denominator: emerging checks sit outside scoring, a bonus counts only the points it earned (it can raise a score, never lower it), and N/A results drop out. Rebalances land on a minor version with a changelog entry. */
+      maxScore: number;
+      /** @description Always present. A bonus check can only add score: a site that lacks the surface is never penalised for failing it. */
+      bonus: boolean;
+      /** @description The check's declared applicability rule. One of: all | domain-only | mcp | mcp-app | api. A value change lands on a minor version with a changelog entry. */
+      applicability: string;
+      /** @description Present only when applicability is 'api'. One of: rest | graphql | either - the API surface the check evaluates. */
+      protocol?: string;
+      /** @description The scan kinds this check can run for - a subset of: domain | mcp | mcp-app. Eligibility, not a guarantee: MCP checks run once per MCP surface detected on the target and report N/A when none is present, and 'api' checks report N/A when the target has no REST or GraphQL surface. */
+      appliesTo: string[];
+      /** @description One of: required | recommended | emerging. Advisory: the required set may grow on a minor version, and every tier change carries a changelog entry. Gate CI on explicit check ids, not on tiers. */
+      tier: string;
+      /** @description One of: verified | emerging. Emerging checks are shown on score pages but excluded from scoring, so do not treat them as score-affecting when selecting checks. */
+      maturity: string;
+      /** @description Always present. True when the check's underlying spec is a draft or emerging standard. */
+      draft: boolean;
+      /** @description Canonical spec or standard URL. Omitted when the check has none. */
+      specUrl?: string;
+      /** @description Generic, target-independent fix guidance. Omitted for the few checks that have none. */
+      recommendation?: string;
+    };
+    CatalogLayer: {
+      /** @description Stable layer id: discovery, accessibility, usability, or payments. Removing or renaming a layer id is a major version change. Note one intentional divergence: the id 'accessibility' carries the display name 'Access'. */
+      id: string;
+      /** @description Display name for the layer. Advisory: it may change on a minor version. */
+      name: string;
+      /** @description The layer's weight in the overall 0-100 score. Weights sum to 100 across the four layers. Advisory: a rebalance lands on a minor version with a changelog entry. */
+      weight: number;
+    };
     JourneyRun: {
       /** @description Run id - the handle for GET /api/journey/runs/{id} and the stream */
       id: string;
@@ -511,6 +617,41 @@ export interface components {
       step_count?: number;
       /** @description Journey/audit contract version (shared SemVer; see docs) */
       contractVersion: string;
+    };
+    JourneyCreatedRun: {
+      /** @description Run id - the handle for GET /api/journey/runs/{id} and the stream */
+      id: string;
+      /**
+       * @description Lifecycle status. failed is terminal; a failed run has no result.
+       * @enum {string}
+       */
+      status: "running" | "succeeded" | "failed";
+      /** @description Curated intent id (see GET /api/journey/intents) */
+      intent_id?: string;
+      /** @description Target domain */
+      domain?: string;
+      /** @description The agent configuration that ran (or is running) */
+      agent: {
+        /** @description Agent harness wire name */
+        harness: string;
+        /** @description Model the harness drives */
+        model: string;
+      };
+      started_at: string;
+      finished_at?: string;
+      /** @description SSE stream for this run: run_id -> trajectory -> processing -> result | error */
+      stream_url: string;
+      /**
+       * @description Canonical success verdict, present once the run finished
+       * @enum {string}
+       */
+      verdict?: "satisfied" | "partial" | "unsatisfied" | "not_gradable";
+      /** @description Billable steps the run took (tool calls, excluding narration and filesystem ops), present once the run finished. This is the same counter run pricing uses. */
+      step_count?: number;
+      /** @description Journey/audit contract version (shared SemVer; see docs) */
+      contractVersion: string;
+      /** @description Echo of the custom intent text the caller sent on this request. Create-response-only: it is never returned by GET /api/journey/runs/{id} or the capped 200, and it is absent on curated runs. Experimental: may change or disappear without a major version. */
+      intent?: string;
     };
     JourneyCappedRun: {
       /** @description Run id - the handle for GET /api/journey/runs/{id} and the stream */
@@ -628,8 +769,8 @@ export interface components {
         cache_read_tokens?: number;
         /** @description Prompt-cache write tokens. Experimental. */
         cache_write_tokens?: number;
-        /** @description The full step tree the agent took */
-        trajectory: {
+        /** @description The full step tree the agent took. Absent on legacy persisted runs. */
+        trajectory?: {
           /** @description Cumulative step tree, in emission order */
           steps: ({
               /** @description Index in steps[] - stable node identifier */
@@ -743,8 +884,8 @@ export interface components {
           /** @description Share of navigations that followed an on-page link rather than a guess */
           link_following_rate: number;
         };
-        /** @description ora's generated read of the run */
-        insight: {
+        /** @description ora's generated read of the run. Absent on legacy persisted runs. */
+        insight?: {
           /** @description ora's generated one-paragraph read of the run */
           summary: string;
           /** @description Bullet observations backing the summary */
@@ -814,8 +955,8 @@ export interface components {
               page_role?: string;
             };
           };
-          /** @description Journey-taxonomy layers (5), distinct from the audit report's 4 scoring layers */
-          journey_layers: ("discovery" | "identity" | "access" | "payments" | "experience")[];
+          /** @description Journey-taxonomy layers (5), distinct from the audit report's 4 scoring layers. Falls back to insight.journey_layers on v1/v2 signals; absent when the run was never classified. */
+          journey_layers?: ("discovery" | "identity" | "access" | "payments" | "experience")[];
         };
       };
     };
@@ -855,8 +996,8 @@ export interface components {
       cache_read_tokens?: number;
       /** @description Prompt-cache write tokens. Experimental. */
       cache_write_tokens?: number;
-      /** @description The full step tree the agent took */
-      trajectory: {
+      /** @description The full step tree the agent took. Absent on legacy persisted runs. */
+      trajectory?: {
         /** @description Cumulative step tree, in emission order */
         steps: ({
             /** @description Index in steps[] - stable node identifier */
@@ -970,8 +1111,8 @@ export interface components {
         /** @description Share of navigations that followed an on-page link rather than a guess */
         link_following_rate: number;
       };
-      /** @description ora's generated read of the run */
-      insight: {
+      /** @description ora's generated read of the run. Absent on legacy persisted runs. */
+      insight?: {
         /** @description ora's generated one-paragraph read of the run */
         summary: string;
         /** @description Bullet observations backing the summary */
@@ -1041,8 +1182,8 @@ export interface components {
             page_role?: string;
           };
         };
-        /** @description Journey-taxonomy layers (5), distinct from the audit report's 4 scoring layers */
-        journey_layers: ("discovery" | "identity" | "access" | "payments" | "experience")[];
+        /** @description Journey-taxonomy layers (5), distinct from the audit report's 4 scoring layers. Falls back to insight.journey_layers on v1/v2 signals; absent when the run was never classified. */
+        journey_layers?: ("discovery" | "identity" | "access" | "payments" | "experience")[];
       };
     };
     JourneyTrajectoryStep: {
@@ -1727,6 +1868,30 @@ export interface operations {
     };
   };
   /**
+   * Get the complete catalog of scanner checks
+   * @description Returns every check the ora scanner can run - stable id, scored layer, max score, applicability, eligible scan kinds, tier, maturity, and fix guidance per check, plus the four scored layers with their weights. Check ids are stable: gate CI on an explicit id list, not on tiers (the required set can grow on a minor version). The document is static and byte-stable between check-set changes, so diffing it detects catalog updates. No parameters. Sends Access-Control-Allow-Origin: * and is CDN-cached for 1 hour. Rate limited to 60 requests per minute per IP - returns 429 with a Retry-After header if exceeded.
+   */
+  listChecks: {
+    responses: {
+      /** @description The complete check catalog */
+      200: {
+        content: {
+          "application/json": components["schemas"]["CheckCatalog"];
+        };
+      };
+      /** @description RATE_LIMIT_EXCEEDED - max 60 requests per minute per IP. */
+      429: {
+        headers: {
+          /** @description Seconds until next allowed request */
+          "Retry-After"?: number;
+        };
+        content: {
+          "application/json": components["schemas"]["ArdErrorResponse"];
+        };
+      };
+    };
+  };
+  /**
    * Discover agent-ready products by intent
    * @description Find the most agent-ready products for a given need. Describe what you're looking for and get products ranked by agent-readiness score. Cached for 5 minutes.
    */
@@ -2128,13 +2293,14 @@ export interface operations {
   };
   /**
    * Run an agent journey against a domain
-   * @description Triggers a real agent run: an AI agent (harness + model) attempts a curated task (an intent) against the given domain, and ora records the trajectory and derives insights. Two-step flow: this endpoint returns fast with a run record whose `stream_url` serves the live trajectory as Server-Sent Events; poll GET /api/journey/runs/{id} instead if you do not want the stream. Only curated intents run publicly (see GET /api/journey/intents) - the server derives the actual agent prompt from the intent id, so no free-text prompt can reach the engine. Only publicly runnable agents are accepted (see GET /api/journey/agents). Unknown body fields are rejected (strict schema). Rate limited three ways: a 20-per-minute burst cap per IP; a per-target cap of 5 runs per rolling 24h per (domain, intent, harness, model) - when a target is over the cap the response is HTTP 200 with the most recent stored run for that target (`rate_limited: true`) plus Retry-After, the freshness analog: a denied trigger still returns the newest result and consumes nothing; and a durable per-caller cap of 10 runs per rolling 24h per IP - exceeded, that one is a real 429 with `retry_after_ms` (there is no cached result to serve for a caller). Successful and capped responses carry X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset headers for the per-target window. Note: journey insights use the 5-layer journey taxonomy (discovery, identity, access, payments, experience), deliberately distinct from the 4 scoring layers of the audit report (POST /api/scan) - never map between the two.
+   * @description Triggers a real agent run: an AI agent (harness + model) attempts a task (an intent) against the given domain, and ora records the trajectory and derives insights. Two-step flow: this endpoint returns fast with a run record whose `stream_url` serves the live trajectory as Server-Sent Events; poll GET /api/journey/runs/{id} instead if you do not want the stream. Two caller tiers. Anonymous: curated intents only (see GET /api/journey/intents) - the server derives the actual agent prompt from the intent id, so no free-text prompt can reach the engine. Keyed: a caller presenting an ora-issued partner API key ('Authorization: Bearer <key>', issued manually - contact ora) may instead send bounded free text (`intent.custom`, 4 to 300 characters, with `intent.domain` required), which the server anchors to the requested domain before dispatch and echoes back on the 201. Free text without a recognized key is a 401 with code CUSTOM_INTENT_REQUIRES_KEY; a curated body with a missing or unrecognized key is never an error and simply runs on the anonymous tier. The keyed free-text tier is also reachable from the ora CLI (ax deep-journey --task, v0.5+). Only publicly runnable agents are accepted (see GET /api/journey/agents). Unknown body fields are rejected (strict schema). Anonymous rate limits, three ways: a 20-per-minute burst cap per IP; a per-target cap of 100 runs per rolling 24h per (domain, intent, harness, model) - when a target is over the cap the response is HTTP 200 with the most recent stored run for that target (`rate_limited: true`) plus Retry-After, the freshness analog: a denied trigger still returns the newest result and consumes nothing; and a durable per-caller cap of 200 runs per rolling 24h per IP - exceeded, that one is a real 429 with `retry_after_ms` (there is no cached result to serve for a caller). Keyed rate limit, one way: 1000 runs per rolling 24h per key, exhaustion being the same 429 with `retry_after_ms`. A keyed caller skips both the burst cap and the per-target cap - free text fragments the target key, so a per-target window over it could never fill. Successful and capped responses carry X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset headers describing exactly one window: the per-target window on an anonymous response, the per-key caller window on a keyed one. Note: journey insights use the 5-layer journey taxonomy (discovery, identity, access, payments, experience), deliberately distinct from the 4 scoring layers of the audit report (POST /api/scan) - never map between the two.
    */
   createJourneyRun: {
     requestBody: {
       content: {
         "application/json": {
-          intent: {
+          /** @description The task to run, as exactly one of two arms. Curated: an `intent_id` the server owns a prompt template for, open to every caller. Custom: bounded free text, accepted only from a caller presenting a partner API key. A body carrying both arms, or neither, is a 400. */
+          intent: OneOf<[{
             /**
              * @description Curated intent to execute (GET /api/journey/intents lists them with labels)
              * @enum {string}
@@ -2145,7 +2311,18 @@ export interface operations {
              * @example stripe.com
              */
             domain?: string;
-          };
+          }, {
+            /**
+             * @description Free-text task for the agent, 4 to 300 characters measured after trimming. REQUIRES an ora-issued partner API key on the request ('Authorization: Bearer <key>'): sent without one, this arm is a 401 with code CUSTOM_INTENT_REQUIRES_KEY, so do not post free text keylessly - use the curated arm instead. The server anchors the text to `domain` before dispatch (that anchored prompt is what runs and what is stored); the 201 echoes back the text you sent, not the anchored form.
+             * @example Sign up for a free account and deploy a sample project
+             */
+            custom: string;
+            /**
+             * @description Target domain (e.g. stripe.com). Required on this arm (it is optional on the curated one) because free text is domain-agnostic and the server anchors the prompt to this target. Validated like a scan target: IP literals, localhost, and malformed hosts are rejected with code INVALID_DOMAIN.
+             * @example stripe.com
+             */
+            domain: string;
+          }]>;
           /**
            * @description Agent harness wire name. The (harness, model) pair must resolve to a publicly runnable agent from GET /api/journey/agents, else 400 UNSUPPORTED_AGENT.
            * @enum {string}
@@ -2160,12 +2337,12 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Per-target cap hit - the freshness analog, not an error: the body is the most recent stored run for this exact (domain, intent, harness, model) target, marked `rate_limited: true`, so CI and agents get the newest result without spending a run. When the served run has finished, the body also carries `verdict` and `step_count`. Replay it via its `stream_url`. */
+      /** @description Per-target cap hit - the freshness analog, not an error: the body is the most recent stored run for this exact (domain, intent, harness, model) target, marked `rate_limited: true`, so CI and agents get the newest result without spending a run. When the served run has finished, the body also carries `verdict` and `step_count`. Replay it via its `stream_url`. Anonymous tier only: a keyed caller skips the per-target cap and never receives this response. */
       200: {
         headers: {
           /** @description Seconds until the target's oldest in-window run ages out */
           "Retry-After"?: number;
-          /** @description Per-target window size (5 runs per rolling 24h) */
+          /** @description Per-target window size (100 runs per rolling 24h) */
           "X-RateLimit-Limit"?: number;
           /** @description Always 0 on a capped response */
           "X-RateLimit-Remaining"?: number;
@@ -2176,27 +2353,33 @@ export interface operations {
           "application/json": components["schemas"]["JourneyCappedRun"];
         };
       };
-      /** @description Run created and dispatched. Open `stream_url` (SSE) to watch the trajectory live, or poll GET /api/journey/runs/{id}. */
+      /** @description Run created and dispatched. Open `stream_url` (SSE) to watch the trajectory live, or poll GET /api/journey/runs/{id}. A keyed custom run gets its own free text back as `intent` here - the create response is the only place any intent text is published, so GET /api/journey/runs/{id} and the capped 200 never carry it, and a curated run has no `intent` at all. */
       201: {
         headers: {
-          /** @description Per-target window size (5 runs per rolling 24h) */
+          /** @description Size of the one window this response describes: the per-target window (100 runs per rolling 24h) for an anonymous caller, the per-key caller window (1000 runs per rolling 24h) for a keyed one */
           "X-RateLimit-Limit"?: number;
-          /** @description Runs left in this target's window, including this one's consumption */
+          /** @description Runs left in that same window, including this one's consumption */
           "X-RateLimit-Remaining"?: number;
-          /** @description Unix seconds when the next per-target slot frees. Absent when the window was empty. */
+          /** @description Unix seconds when the next slot in that same window frees. Absent when the window was empty. */
           "X-RateLimit-Reset"?: number;
         };
         content: {
-          "application/json": components["schemas"]["JourneyRun"];
+          "application/json": components["schemas"]["JourneyCreatedRun"];
         };
       };
-      /** @description Invalid input: schema failure (including unknown body fields - the contract is strict), `code: "INVALID_DOMAIN"` for a domain the scanner would reject, or `code: "UNSUPPORTED_AGENT"` for a (harness, model) pair that is not publicly runnable. */
+      /** @description Invalid input: schema failure (including unknown body fields - the contract is strict, and a body matching neither intent arm or both of them lands here), `code: "INVALID_DOMAIN"` for a domain the scanner would reject, or `code: "UNSUPPORTED_AGENT"` for a (harness, model) pair that is not publicly runnable. */
       400: {
         content: {
           "application/json": components["schemas"]["ErrorResponse"];
         };
       };
-      /** @description Caller limit exceeded - the 20-per-minute burst cap, or the durable per-caller budget (10 runs per rolling 24h per IP; body carries `retry_after_ms`). Per-TARGET saturation is the 200 above, not this. */
+      /** @description `code: "CUSTOM_INTENT_REQUIRES_KEY"` - the request sent a custom free-text intent without a recognized ora-issued partner API key. An absent, malformed, and unrecognized key all land here alike, so the status never doubles as a key-validity oracle. Two ways forward: run a curated intent instead (GET /api/journey/intents lists them, and that arm needs no key), or ask ora for a partner key - they are issued manually on request, so contact us at the address in this document's info.contact. */
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+      /** @description Caller limit exceeded - the 20-per-minute burst cap (anonymous callers only; a keyed caller skips it), or the durable per-caller budget (10 runs per rolling 24h per IP anonymous, 1000 per rolling 24h per key; body carries `retry_after_ms`). Per-TARGET saturation is the 200 above, not this. */
       429: {
         headers: {
           /** @description Seconds until next allowed request */

--- a/src/contract/version.ts
+++ b/src/contract/version.ts
@@ -2,4 +2,4 @@
 // Regenerate: pnpm contract:gen [--url <openapi.json url>]
 
 /** The ora contract version (spec info.version) these types were generated from. */
-export const BUILT_AGAINST = "1.11.0";
+export const BUILT_AGAINST = "1.15.0";

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,7 +114,7 @@ const deepJourney = defineCommand({
 	meta: {
 		name: "deep-journey",
 		description:
-			"Run a real AI agent at a site on a curated task via ora's public API (no key needed; exit codes: 0 ok, 1 run failed, 2 usage, 3 API error)",
+			"Run a real AI agent at a site on a curated task — or, with a partner API key, a free-text one — via ora's public API (exit codes: 0 ok, 1 run failed, 2 usage, 3 API error)",
 	},
 	args: {
 		url: {
@@ -135,6 +135,16 @@ const deepJourney = defineCommand({
 			description: "Print the terminal run detail as JSON",
 			default: false,
 		},
+		task: {
+			type: "string",
+			description:
+				"Free-text task for the agent (needs a partner API key; mutually exclusive with --intent)",
+		},
+		"api-key": {
+			type: "string",
+			description:
+				"ora-issued partner API key: unlocks --task and the 1000/24h keyed allowance; also read from ORA_PARTNER_API_KEY",
+		},
 		"no-stream": {
 			type: "boolean",
 			description: "Skip the live trajectory stream and poll for the result instead",
@@ -146,6 +156,8 @@ const deepJourney = defineCommand({
 		process.exitCode = await deepJourneyCommand({
 			url: args.url as string,
 			intent: args.intent as string | undefined,
+			task: args.task as string | undefined,
+			apiKey: args["api-key"] as string | undefined,
 			agent: args.agent as string | undefined,
 			json: Boolean(args.json),
 			noStream: Boolean(args["no-stream"]),
@@ -196,7 +208,7 @@ function helpScreen(): string {
 		"",
 		`  ${d("Commands:")}`,
 		`    audit ${d("<url>")}         ${d("Score a site's agent readiness")}`,
-		`    deep-journey ${d("<url>")}  ${d("Run a real agent at a site on a curated task (no key needed)")}`,
+		`    deep-journey ${d("<url>")}  ${d("Run a real agent at a site on a curated or free-text task")}`,
 		`    journey ${d("<intent>")}    ${d("Send a real agent at a site and watch it live (workspace)")}`,
 		`    skill ${d("[name]")}        ${d("List, print, or install ora's agent skills")}`,
 		"",
@@ -222,10 +234,12 @@ function helpScreen(): string {
 		"",
 		`  ${d("deep-journey options:")}`,
 		`    --intent <id>    ${d("Curated task id, e.g. pricing, signup, api-docs (server default when omitted)")}`,
+		`    --task <text>    ${d("Free-text task (needs a partner API key; replaces --intent)")}`,
+		`    --api-key <k>    ${d("ora partner API key: unlocks --task + 1000 runs/24h; also read from ORA_PARTNER_API_KEY")}`,
 		`    --agent <id>     ${d("Agent from the public roster (default: ora's pick)")}`,
 		`    --no-stream      ${d("Poll for the result instead of streaming the trajectory")}`,
 		`    --json           ${d("Print the terminal run detail as JSON")}`,
-		`    ${d("no key needed · public caps: 5 runs/24h per target, 10 runs/24h per IP")}`,
+		`    ${d("no key needed · public caps: 100 runs/24h per target, 200 runs/24h per IP")}`,
 		"",
 		`  ${d("journey options:")}`,
 		`    --domain <d>     ${d("Site the agent targets (e.g. stripe.com)")}`,


### PR DESCRIPTION
## What

Wires the server's keyed journey tier (live since contract 1.12.0) into the CLI, and fixes the failure mode where a quiet stream abandoned a paid run.

- **`--api-key` / `ORA_PARTNER_API_KEY`** (fallback: `ORA_SCAN_API_KEY`) — sent as `Authorization: Bearer` on the run trigger. Keyed callers get 1000 runs/24h per key, no per-target cap, no burst guard. A wrong key with a curated intent silently degrades to keyless (server convention), so this is always safe to send.
- **`--task "<free text>"`** — drives the keyed custom intent arm; mutually exclusive with `--intent`, fails fast locally without a key, and the server's `CUSTOM_INTENT_REQUIRES_KEY` 401 maps to the same actionable message.
- **Stream-to-poll fallback** — yesterday's production failure (`stream timed out — no frames for 120s`, exit 3) abandoned a run that was still executing and billing server-side. Any stream failure now degrades to polling the run detail; the existing still-running guard reports if the run is genuinely stuck.
- **Contract regenerated at 1.15.0** — kills the runtime drift warning (built 1.11.0 vs served 1.13.0+) and picks up the raised anonymous caps (100/24h per target, 200/24h per IP); caps messaging updated in help, README, and error text.

## Demo

```sh
export ORA_PARTNER_API_KEY=...   # name:secret entry in ora's ORA_PARTNER_API_KEYS env
npx @ora-ai/ax deep-journey zapier.com --intent pricing
npx @ora-ai/ax deep-journey zapier.com --task "Find how to build a Slack → Sheets zap"
```

## Verification

- 95 tests passing (10 new, written TDD: bearer header, env fallback, custom arm body, 401 mapping, quiet-stream fallback, flag exclusivity)
- biome + tsc clean, build + smoke + verify:pack pass

## Merge order

Merge **after** eralabs-ai/ora#850 is deployed — the pinned contract here is 1.15.0, and the CI drift check regenerates from production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)