### PR TITLE
docs: correct README claims that drifted from the shipped CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ora platform API (agentic journeys / runs). Copy to `.env` and fill in.
-# The scan command uses the public ora.ai host and needs none of these —
-# `ax scan <url>` works with zero configuration.
+# The public commands (audit, deep-journey, skill) use the public ora.ai host
+# and need none of these — `ax audit <url>` works with zero configuration.
 
 # Secret API key (looks like ora_sk_...). Exchanged for a short-lived bearer token.
 ORA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Score any site's agent readiness — and watch real AI agents navigate it. Power
 npx @ora-ai/ax audit https://stripe.com
 ```
 
-Three commands:
+Four commands:
 
 - **`audit <url>`** — run ora's hosted agent-readiness audit against a site: live progress, then a layered report of what passed, what's broken, and ora's ranked list of the highest-impact fixes (or `--json` for the raw contract payload). No account or API key needed. Gate CI with `--min-score`.
+- **`deep-journey <url>`** — run a real AI agent at a site on one of ora's curated tasks through the public journey API: no key, no workspace. A partner API key unlocks free-text tasks (`--task`) and a larger allowance.
 - **`journey "<intent>"`** — send a real AI agent (claude-code, codex, …) at a site and watch its navigation live as a boxed node-graph, then get the scored insight, tokens, and cost. Requires an `ORA_API_KEY`.
 - **`skill [name]`** — list, print, or install ora's agent skills, digest-verified from the public registry.
 
@@ -23,7 +24,7 @@ ax audit <url> [--min-score n] [--max-age s] [--force] [--tunnel-cmd c] [--api-k
   Stripe offers strong developer resource discoverability, but lacks an OpenAPI specification.
 
   Discovery   ██████░░░░ 6/9 passed · 1 skipped
-    ✗ Issues (3)
+    ✗ Issues (2)
     ┌───┬──────────────┬───────────────────────────┬──────────────────────────────┐
     │   │ Check        │ What's wrong              │ How to fix                   │
     ├───┼──────────────┼───────────────────────────┼──────────────────────────────┤
@@ -109,7 +110,7 @@ Runs a real AI agent at a site through ora's **public** journey API — no key, 
   For the 4-layer readiness audit, run: ax audit stripe.com
 ```
 
-Anonymous callers run curated intents (`pricing`, `signup`, `api-docs`, `get started`, `support`, …) — list them with `GET https://ora.ai/api/journey/intents`, and the accepted agents with `GET https://ora.ai/api/journey/agents`. The public caps are 100 runs per rolling 24h per target and 200 runs per 24h per IP; a target at its cap answers with the most recent stored run (`rate_limited: true`) instead of an error, so repeat CI invocations are cheap. Verdict and step count come from ora's contract as-is — the CLI never re-judges a run.
+Anonymous callers run curated intents (`pricing`, `signup`, `api-docs`, `integrate`, `support`, …) — list them with `GET https://ora.ai/api/journey/intents`, and the accepted agents with `GET https://ora.ai/api/journey/agents`. The public caps are 100 runs per rolling 24h per target and 200 runs per 24h per IP (plus a 20/min burst limit); a target at its cap answers with the most recent stored run (`rate_limited: true`) instead of an error, so repeat CI invocations are cheap. Verdict and step count come from ora's contract as-is — the CLI never re-judges a run.
 
 **Keyed tier:** an ora-issued partner API key (`--api-key`, or `ORA_PARTNER_API_KEY` / `ORA_SCAN_API_KEY` in the environment) unlocks `--task` — a free-text task of 4–300 characters that replaces the curated intent — and moves the caller to an allowance of 1000 runs per rolling 24h per key with no per-target cap and no burst guard. Keys are issued manually by ora (no self-serve signup). A wrong or unrecognized key with a *curated* intent silently degrades to the anonymous tier; `--task` without a recognized key is an error.
 
@@ -134,9 +135,10 @@ This differs from `ax journey` (below), which drives the authenticated platform 
 ax skill                                # list the registry
 ax skill agent-ready-website            # print a SKILL.md
 ax skill agent-ready-website --install  # write .claude/skills/<name>/SKILL.md
+ax skill --json                         # the raw registry index
 ```
 
-Skills come from ora's public registry (`https://ora.ai/.well-known/agent-skills/`) and every byte is verified against the registry's sha256 digest before it is printed or installed. Skill content is never bundled into this package. `--dir <path>` overrides the install directory.
+Skills come from ora's public registry (`https://ora.ai/.well-known/agent-skills/`) and every byte is verified against the registry's sha256 digest before it is printed or installed. Skill content is never bundled into this package. `--dir <path>` overrides the install directory, and `--json` prints the registry index as JSON instead of the formatted list.
 
 ## journey
 
@@ -239,6 +241,7 @@ A `.env` in the working directory is read on startup — copy `.env.example` and
 |---|---|---|---|
 | `ORA_API_URL` | audit, deep-journey, skill | `https://ora.ai` | Public API base (no auth) |
 | `ORA_PLATFORM_URL` | journey | `https://api.agentfront.sh` | Authenticated platform API base |
+| `ORA_TUNNEL_CMD` | audit | — (optional) | Tunnel command for a local target (same as `--tunnel-cmd`) |
 | `ORA_API_KEY` | journey | — (required) | Secret key (`ora_sk_…`), exchanged for a short-lived bearer token |
 | `ORA_SCAN_API_KEY` | audit, deep-journey | — (optional) | ora-issued scan API key; lifts every scan rate limit (issued manually by ora). deep-journey accepts it as a partner-key fallback |
 | `ORA_PARTNER_API_KEY` | deep-journey | — (optional) | ora-issued partner API key; unlocks `--task` and the 1000/24h keyed allowance |
@@ -275,7 +278,7 @@ node scripts/mock-scan-server.mjs &
 ORA_API_URL=http://localhost:8799 node dist/main.cjs audit https://example.com
 ```
 
-To exercise the published-package experience locally: `npm pack`, then `npx ./ora-ai-ax-0.2.0.tgz audit https://example.com`, or `pnpm link --global` and use `ax` directly.
+To exercise the published-package experience locally: `npm pack`, then `npx ./ora-ai-ax-<version>.tgz audit https://example.com`, or `pnpm link --global` and use `ax` directly.
 
 ## Releasing
 


### PR DESCRIPTION
Audited every claim in `README.md` against `src/` and against the server-side behaviour in `eralabs-ai/ora`. Most of it holds up (see below); these did not.

## Wrong

- **"Three commands"** — there are four. `src/main.ts` registers `audit`, `deep-journey`, `journey`, `skill`, and the curated help screen lists all four. `deep-journey` shipped in #14 and already has its own README section, but the intro bullet list was never updated.
- **`get started` is not an intent id.** It is the *label* of the intent whose id is `integrate` (`src/lib/journey/curated-intents.ts` in `ora`). `src/commands/deep-journey.ts` validates `--intent` against the roster from `/api/journey/intents`, so the documented value exited `2` with "unknown intent".
- **Stale tarball version** in the development section (`ora-ai-ax-0.2.0.tgz`, package is at 0.5.0). Now `<version>`, so it cannot re-stale on the next release.

## Incomplete

- `ORA_TUNNEL_CMD` was missing from the environment-variable table, although that table claims to enumerate the configuration (the variable is read in `src/commands/audit.ts` and documented in `.env.example`).
- `ax skill --json` exists (`src/main.ts`, `src/commands/skill.ts`) and was undocumented.
- The public deep-journey caps omitted the anonymous 20/min/IP burst guard (`src/app/api/journey/runs/route.ts` in `ora`), although the keyed paragraph promises a key removes "the burst guard" and the audit section documents its own 10/min limit.
- Cosmetic: the sample audit report said "Issues (3)" above a two-row table, which also contradicted its own `6/9 passed · 1 skipped` bar.

## Also

`.env.example` — which the README tells users to copy — still described the `ax scan` command that became `ax audit` with no alias (the README's own migration note says so).

## Verified accurate, left alone

Scan limits (30/24h + 6 force + 10/min burst, keyed callers fully exempt, an unrecognized key degrading to keyless rather than 401); `--max-age` default 6h clamped to 1-24h; journey caps 100/target/24h, 200/IP, 1000/key keyed with no per-target cap; `--task` bounds of 4-300 characters and the capability 401; all three exit-code tables; the `mcpAuthRequired` gate skip; the 120s stream-idle to polling fallback; tunnel posture (no bundled vendor, ephemeral storage, URL read from stdout or stderr); skill digest verification; contract-drift CI plus the once-per-process upgrade warning; every library export in the two code samples; env defaults; and the development scripts including the mock server's port.

Docs only - no source changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1mHNk6dch7yxnGbBiCoQ9)_