### PR TITLE
chore: keep claude local state out of git and biome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ coverage/
 .env
 *.tsbuildinfo
 .DS_Store
+
+# claude code local harness state (worktrees from EnterWorktree, per-user permissions)
+.claude/worktrees/
+.claude/settings.local.json

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
+	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,


### PR DESCRIPTION
## Motivation
`pnpm lint` fails locally whenever a Claude Code worktree exists under `.claude/worktrees/` (biome refuses the nested `biome.json` roots) and then tries to format the per-user `.claude/settings.local.json`. Neither is a project file.

## Objective
Gitignore `.claude/worktrees/` and `.claude/settings.local.json` (same as the ora repo) and set biome `vcs.useIgnoreFile` so the ignore list is the single source of truth. `biome check .` now exits 0 in a checkout with live worktrees; tests 95/95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)