### PR TITLE
fix(contract): regenerate against ora 1.20.x and wake the drift alarm on a schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,15 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # The contract-drift job below is the alarm for "ora shipped a contract this
+  # build was not generated against". Until now it only ran on our own PRs, so
+  # nothing woke it when ora released: 1.20.0 shipped and every `ax` run warned
+  # about a stale contract for days before anyone noticed. On this schedule the
+  # alarm fires on its own; workflow_dispatch is for checking straight after a
+  # known ora release instead of waiting for the next run.
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
 
 # Least privilege: CI only ever reads the repo.
 permissions:
@@ -22,6 +31,7 @@ jobs:
   quality:
     name: Lint & Typecheck
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -47,6 +57,7 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     strategy:
       # One Node version failing shouldn't hide the result on the others.
       fail-fast: false
@@ -73,6 +84,7 @@ jobs:
   build:
     name: Build & Package
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/src/contract/types.gen.ts
+++ b/src/contract/types.gen.ts
@@ -419,10 +419,10 @@ export interface components {
       /** @enum {string} */
       source: "ora.ai";
       /**
-       * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
+       * @description The contract version this payload conforms to. SemVer: a major means a response-envelope break - a stable field removed, renamed, or changed in meaning, or the default response format flipping - and is safe to pin. Additive changes and check-catalog membership changes ship on a minor. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.20.0";
+      contractVersion: "1.20.1";
       /**
        * @description Present only when this body is a stored result served by the freshness gate instead of a fresh scan. Absent on a live scan.
        * @enum {boolean}
@@ -618,10 +618,10 @@ export interface components {
       /** @enum {string} */
       source: "ora.ai";
       /**
-       * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
+       * @description The contract version this payload conforms to. SemVer: a major means a response-envelope break - a stable field removed, renamed, or changed in meaning, or the default response format flipping - and is safe to pin. Additive changes and check-catalog membership changes ship on a minor. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.20.0";
+      contractVersion: "1.20.1";
       /** @description Wall-clock duration of the scan that produced this stored result */
       durationMs: number | null;
       /**
@@ -659,13 +659,13 @@ export interface components {
         [key: string]: unknown;
       } | null;
     };
-    /** @description The complete catalog of scanner checks. Stability classes: every field's shape and presence rule is stable within a major version; check and layer ids are identity, so removing, renaming, or changing the meaning of one is a major version change; every other value (scores, weights, layer assignments, applicability, tiers, maturity, prose) is advisory and may change on a minor version, with score-relevant changes recorded in the contract changelog. Gate CI on an explicit list of check ids. */
+    /** @description The complete catalog of scanner checks. Stability classes: every field's shape and presence rule is stable within a major version; layer ids are envelope identity, so removing or renaming one is a major version change; check ids never change meaning while they exist, but catalog membership may change on a minor, with a contract changelog entry and a deprecation window; every other value (scores, weights, layer assignments, applicability, tiers, maturity, prose) is advisory and may change on a minor version, with score-relevant changes recorded in the contract changelog. Gate CI on an explicit list of check ids. */
     CheckCatalog: {
       /**
-       * @description The contract version this catalog conforms to - identical to the OpenAPI info.version and the MCP server version. SemVer: a major means a stable field or a check or layer id was removed, renamed, or changed meaning. The full versioning policy is published in the API description at /api/openapi.json.
+       * @description The contract version this catalog conforms to - identical to the OpenAPI info.version and the MCP server version. SemVer: a major means a response-envelope break (a stable field, or a layer id, removed or renamed or changed in meaning, or the default response format flipping) and is safe to pin; check-catalog membership changes ship on a minor. The full versioning policy is published in the API description at /api/openapi.json.
        * @enum {string}
        */
-      contractVersion: "1.20.0";
+      contractVersion: "1.20.1";
       /** @description The four scored layers in scoring order, with display name and current weight. */
       layers: {
           /** @description Stable layer id: discovery, accessibility, usability, or payments. Removing or renaming a layer id is a major version change. Note one intentional divergence: the id 'accessibility' carries the display name 'Access'. */
@@ -677,7 +677,7 @@ export interface components {
         }[];
       /** @description All catalogued checks. Array order is not contractual: key by id. */
       checks: ({
-          /** @description Stable check identifier, safe to persist, to gate CI on, and to pass in POST /api/scan/checks. Removing, renaming, or changing the meaning of an id is a major version change. */
+          /** @description Stable check identifier, safe to persist, to gate CI on, and to pass in POST /api/scan/checks. An id never changes meaning while it exists. Catalog membership is not frozen: an id can be retired or renamed on a MINOR version, always with a contract changelog entry and a deprecation window. Check ids identify catalog entries rather than response-envelope fields, so a client parsing responses keeps working when one disappears; a client gating on an explicit id list reads the changelog. */
           id: string;
           /** @description Human-readable check title. Advisory display prose. */
           name: string;
@@ -710,7 +710,7 @@ export interface components {
         })[];
     };
     CatalogCheck: {
-      /** @description Stable check identifier, safe to persist, to gate CI on, and to pass in POST /api/scan/checks. Removing, renaming, or changing the meaning of an id is a major version change. */
+      /** @description Stable check identifier, safe to persist, to gate CI on, and to pass in POST /api/scan/checks. An id never changes meaning while it exists. Catalog membership is not frozen: an id can be retired or renamed on a MINOR version, always with a contract changelog entry and a deprecation window. Check ids identify catalog entries rather than response-envelope fields, so a client parsing responses keeps working when one disappears; a client gating on an explicit id list reads the changelog. */
       id: string;
       /** @description Human-readable check title. Advisory display prose. */
       name: string;
@@ -764,7 +764,7 @@ export interface components {
        * @description The contract version this response conforms to - identical to the OpenAPI info.version and the MCP server version. The full versioning policy is published in the API description at /api/openapi.json.
        * @enum {string}
        */
-      contractVersion: "1.20.0";
+      contractVersion: "1.20.1";
       /** @description The apex domain derived from the requested URL. */
       domain: string;
       /** @description The normalized URL the run targeted. */

--- a/src/contract/types.gen.ts
+++ b/src/contract/types.gen.ts
@@ -422,7 +422,7 @@ export interface components {
        * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.19.1";
+      contractVersion: "1.20.0";
       /**
        * @description Present only when this body is a stored result served by the freshness gate instead of a fresh scan. Absent on a live scan.
        * @enum {boolean}
@@ -621,7 +621,7 @@ export interface components {
        * @description The contract version this payload conforms to. SemVer: a major means a stable field or check id was removed, renamed, or changed meaning. See docs/api.md -> Contract and versioning.
        * @enum {string}
        */
-      contractVersion: "1.19.1";
+      contractVersion: "1.20.0";
       /** @description Wall-clock duration of the scan that produced this stored result */
       durationMs: number | null;
       /**
@@ -665,7 +665,7 @@ export interface components {
        * @description The contract version this catalog conforms to - identical to the OpenAPI info.version and the MCP server version. SemVer: a major means a stable field or a check or layer id was removed, renamed, or changed meaning. The full versioning policy is published in the API description at /api/openapi.json.
        * @enum {string}
        */
-      contractVersion: "1.19.1";
+      contractVersion: "1.20.0";
       /** @description The four scored layers in scoring order, with display name and current weight. */
       layers: {
           /** @description Stable layer id: discovery, accessibility, usability, or payments. Removing or renaming a layer id is a major version change. Note one intentional divergence: the id 'accessibility' carries the display name 'Access'. */
@@ -764,7 +764,7 @@ export interface components {
        * @description The contract version this response conforms to - identical to the OpenAPI info.version and the MCP server version. The full versioning policy is published in the API description at /api/openapi.json.
        * @enum {string}
        */
-      contractVersion: "1.19.1";
+      contractVersion: "1.20.0";
       /** @description The apex domain derived from the requested URL. */
       domain: string;
       /** @description The normalized URL the run targeted. */
@@ -1982,7 +1982,7 @@ export interface components {
       message?: string;
       /** @description Optional machine-readable error code (e.g. EPHEMERAL_CLOBBER, ENDPOINT_NOT_FOUND, RATE_LIMITED, INVALID_DOMAIN) */
       code?: string;
-      /** @description Present on a 429 from the durable daily scan budget: milliseconds until a slot frees, the same interval the Retry-After header carries in seconds. Matches the deny body /api/journey/runs sends, so one client handler covers every rate-limited ora endpoint. */
+      /** @description Present on a 429 from the durable daily scan budget: milliseconds until a slot frees, the same interval the Retry-After header carries in seconds. Every rate-limited ora endpoint sends the same deny body, so one client handler covers them all. */
       retry_after_ms?: number;
       /** @description Optional structured validation detail (Zod flatten) on a schema rejection. */
       details?: {
@@ -2056,7 +2056,12 @@ export interface components {
   responses: never;
   parameters: never;
   requestBodies: never;
-  headers: never;
+  headers: {
+    /** @description Present only once this endpoint (or the request's API version) has been deprecated: the date the deprecation took effect, per the IETF Deprecation header. Absent on every endpoint today - its appearance is the machine-readable start of the deprecation window described in this API's versioning policy. */
+    Deprecation: string;
+    /** @description Present only once a removal date has been committed for this endpoint (RFC 8594): the HTTP-date after which the endpoint stops answering. Per the versioning policy, this is always at least 90 days after the Deprecation header first appears, and the migration path is documented in the API reference at /docs. */
+    Sunset: string;
+  };
   pathItems: never;
 }
 
@@ -2112,6 +2117,8 @@ export interface operations {
         headers: {
           /** @description Present only on a freshness-window hit: the age of the returned stored result in seconds. */
           Age?: number;
+          Deprecation: components["headers"]["Deprecation"];
+          Sunset: components["headers"]["Sunset"];
         };
         content: {
           "application/json": components["schemas"]["ScanResult"] & ({
@@ -2342,6 +2349,10 @@ export interface operations {
     responses: {
       /** @description Cached scan result. With `?competitors=1`, also carries a `competitors` object (category leaders + neighbor window drawn from the leaderboard). When `analysisStatus` is `"stuck"`, the body also includes a `next_action` envelope. With `?format=audit` the body is `#/components/schemas/AuditScoreResult` and the recovery envelope is the camelCase `nextAction`. */
       200: {
+        headers: {
+          Deprecation: components["headers"]["Deprecation"];
+          Sunset: components["headers"]["Sunset"];
+        };
         content: {
           "application/json": components["schemas"]["ScanResult"] & ({
             /** @description Present only when the request passed ?competitors=1. Category leaders + neighbor window from the leaderboard, independent of analysis completeness. Null when the domain has no market category (unclassified / Community domains, or no leaderboard row) or when competitive data is temporarily unavailable. */

--- a/src/contract/version.ts
+++ b/src/contract/version.ts
@@ -2,4 +2,4 @@
 // Regenerate: pnpm contract:gen [--url <openapi.json url>]
 
 /** The ora contract version (spec info.version) these types were generated from. */
-export const BUILT_AGAINST = "1.19.1";
+export const BUILT_AGAINST = "1.20.0";

--- a/src/contract/version.ts
+++ b/src/contract/version.ts
@@ -2,4 +2,4 @@
 // Regenerate: pnpm contract:gen [--url <openapi.json url>]
 
 /** The ora contract version (spec info.version) these types were generated from. */
-export const BUILT_AGAINST = "1.20.0";
+export const BUILT_AGAINST = "1.20.1";


### PR DESCRIPTION
## Why

ora shipped contract 1.20.0 on 2026-08-22 (the re-land of the check audit after the 2.1.0 revert). This build stayed pinned to 1.19.1, and because `isNewerContract` compares major *and* minor, every `ax` invocation against production has been printing the stale-contract warning to stderr:

```
ora reports contract 1.20.0; this CLI was built against 1.19.1.
Newer fields may be missing from the output - upgrade with: npm i -g @ora-ai/ax@latest
```

The upgrade it advises is a dead end. The last published release predates even the 1.19.1 regen, so `@ora-ai/ax@latest` is built against 1.17.0 and has been warning since 1.18.0 shipped.

The deeper problem is that nothing told us. `contract-drift` exists precisely to catch "ora shipped a contract this build was not generated against", and it only ran on pull requests to this repo, so the one event it exists to detect never triggered it. It was found by hand, days later.

## What

**1. Regenerated the contract artifacts** against ora contract **1.20.1** (eralabs-ai/ora#916, merged and deployed). `pnpm contract:gen`, no hand edits. The diff is `BUILT_AGAINST`, the four `contractVersion` enums, the `Deprecation` and `Sunset` response headers 1.20.0 declares, one reworded error-field description, and the corrected SemVer prose 1.20.1 shipped.

That prose matters to this repo specifically. Before 1.20.1 the served document contradicted itself - `info.description` said check-catalog membership changes ship on a minor, while `CatalogCheck.id` and the `contractVersion` fields said a removed check id is a major - and these generated types were carrying the pre-amendment rule out to consumers.

**2. The drift alarm now runs on a schedule** (daily) and on manual dispatch, with the other three jobs restricted to pull requests since they have nothing new to say without a code change. An ora release will now surface here on its own rather than waiting for someone to open a PR.

## Notes

Fixtures under `src/api/__fixtures__/` keep the three check ids ora retired in 1.20.0 (`content-efficiency`, `content-crawl-depth`, `speakable-content`). They are captured real responses, and stored scans that predate the release still carry those ids, so they remain truthful as recorded payloads. Regenerating them would mean hand-editing captured data.

One cosmetic artifact of `openapi-typescript` v6: the `$ref`-ed `Deprecation` / `Sunset` headers are emitted as required rather than optional, though the spec declares neither as required. It is deterministic, so the drift check stays stable, and the CLI does not consume those types.

## Testing

`pnpm lint`, `typecheck`, `test:ci` (95 passing), `build`, `smoke`, `verify:pack` all pass. `Contract drift vs production` is green against the deployed 1.20.1 spec, which independently confirms these artifacts match what ora actually serves.

Behaviour verified against the built bundle rather than inferred:

```
BUILT_AGAINST: 1.20.1
  server 1.20.0 -> warns: false
  server 1.20.1 -> warns: false
  server 1.20.2 -> warns: false     # patch drift is silent by design
  server 1.21.0 -> warns: true
  server 2.0.0  -> warns: true
```

## After merging

Dispatch the Release workflow from `main` (patch bump). The repo fix alone does not reach users: releases here are manual `workflow_dispatch`, so installed CLIs keep printing the stale-contract warning until a publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bRdAo21nDiCPHJyQYfGgF