### PR TITLE
feat(package): rename @ora-ai/ax to unscoped ax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
       id-token: write # OIDC token for npm provenance attestation
     env:
       # setup-node writes an .npmrc referencing ${NODE_AUTH_TOKEN}, so every npm and
-      # pnpm call warns until something defines it. The publish step overrides this
-      # with the real token; an empty default just keeps the secret scoped there
-      # while removing a warning that otherwise buries real errors in the log.
+      # pnpm call warns until something defines it. Publishing itself is tokenless
+      # (OIDC Trusted Publishing); the empty default only silences a warning that
+      # otherwise buries real errors in the log.
       NODE_AUTH_TOKEN: ""
     steps:
       - name: Guard — releases ship from main only
@@ -143,12 +143,16 @@ jobs:
       - name: Verify publishable tarball
         run: pnpm verify:pack
 
+      # OIDC Trusted Publishing (configured on npmjs.com for this repo +
+      # workflow) needs npm >= 11.5.1 for the token exchange; Node 22 bundles
+      # npm 10, which would silently skip OIDC and fail as unauthenticated.
+      - name: Upgrade npm for OIDC Trusted Publishing
+        run: |
+          npm install -g npm@11
+          npm --version
+
       - name: Publish to npm
         env:
-          # Swap for OIDC Trusted Publishing later — see RELEASING.md. The
-          # id-token permission this job already holds is the only other
-          # requirement, so the migration is deleting these two lines.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
         run: pnpm smoke
 
       # Catches publishing an unbuilt or truncated bundle — npm would accept it
-      # silently and break every `npx @ora-ai/ax`. Last chance while the version
+      # silently and break every `npx ax`. Last chance while the version
       # is still free; once published it can never be reused.
       - name: Verify publishable tarball
         run: pnpm verify:pack

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Score any site's agent readiness — and watch real AI agents navigate it. Powered by [ora](https://ora.ai)'s hosted APIs.
 
 ```
-npx @ora-ai/ax audit https://stripe.com
+npx ax audit https://stripe.com
 ```
 
 Four commands:
@@ -58,7 +58,7 @@ The **Top fixes** list is ranked by ora server-side (non-bonus fixes first, then
 
 ```yaml
 - name: Agent-readiness gate
-  run: npx @ora-ai/ax audit https://your-site.com --min-score 70
+  run: npx ax audit https://your-site.com --min-score 70
 ```
 
 Exit codes are the contract:
@@ -206,7 +206,7 @@ For local development, copy `.env.example` to `.env` — the CLI reads a `.env` 
 The same contract-typed client the CLI uses is importable:
 
 ```ts
-import { audit } from "@ora-ai/ax";
+import { audit } from "ax";
 
 const { result } = await audit("stripe.com");
 console.log(result.score, result.grade, result.topFixes);
@@ -217,7 +217,7 @@ console.log(result.score, result.grade, result.topFixes);
 The public journey client is exported too — the same no-key path as `ax deep-journey`:
 
 ```ts
-import { deepJourney, fetchJourneyAgents } from "@ora-ai/ax";
+import { deepJourney, fetchJourneyAgents } from "ax";
 
 const { agents, defaultId } = await fetchJourneyAgents();
 const agent = agents.find((a) => a.id === defaultId)!;
@@ -248,7 +248,7 @@ A `.env` in the working directory is read on startup — copy `.env.example` and
 
 ## Contract versioning
 
-The audit types are generated from ora's served OpenAPI spec (`pnpm contract:gen`); the build is pinned to a contract version and CI fails when production drifts from the checked-in types. At runtime, the CLI prints one stderr warning when ora reports a newer contract than the build — upgrade with `npm i -g @ora-ai/ax@latest`.
+The audit types are generated from ora's served OpenAPI spec (`pnpm contract:gen`); the build is pinned to a contract version and CI fails when production drifts from the checked-in types. At runtime, the CLI prints one stderr warning when ora reports a newer contract than the build — upgrade with `npm i -g ax@latest`.
 
 ## Migrating from 0.1.x
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,18 +30,25 @@ Rehearse anything uncertain with `dry_run` checked: it does every step including
 
 ## One-time setup
 
-### `NPM_TOKEN`
+### OIDC Trusted Publishing
 
-Create a **granular access token** on npmjs.com with read+write on the `ax`
-**package** — `ax` is unscoped, so a token limited to the `@ora-ai` scope does
-*not* cover it; select the package explicitly (or "all packages"). Then:
+Publishing is tokenless: npm verifies the workflow's identity through GitHub's
+OIDC provider. The trusted publisher is configured on npmjs.com → `ax` →
+**Settings → Trusted Publisher**: GitHub Actions, org `eralabs-ai`, repository
+`ora-cli`, workflow `release.yml`, no environment, `npm publish` allowed. The
+workflow's `id-token: write` permission plus npm ≥ 11.5.1 (the job upgrades
+npm explicitly — Node 22 bundles npm 10, which silently skips the OIDC
+exchange) are the only other requirements.
 
-```sh
-gh secret set NPM_TOKEN --repo eralabs-ai/ora-cli
-```
+If you ever add an `environment:` to the release job (see hardening below),
+update the trusted publisher's environment name to match in the same breath —
+they must agree or publishes are rejected.
 
-Granular tokens bypass 2FA prompts, which is what makes automated publishing
-work. Give it an expiry and diarise the rotation.
+If tokenless publishing is ever broken and a release can't wait, the fallback
+is a **granular access token** with read+write on the `ax` **package** — `ax`
+is unscoped, so a token limited to the `@ora-ai` scope does *not* cover it —
+stored as `NPM_TOKEN` and passed as `NODE_AUTH_TOKEN` in the publish step.
+Prefer fixing OIDC.
 
 ### npm org
 
@@ -92,21 +99,15 @@ correctly refuse, because that version is already on npm.
 the fix forward under a new version. `npm deprecate` the bad one with a message
 pointing at the replacement.
 
-## Migrating to OIDC Trusted Publishing
+## After the first tokenless release
 
-Trusted Publishing removes the long-lived `NPM_TOKEN` entirely: npm verifies the
-workflow's identity through GitHub's OIDC provider instead of a stored
-credential. It requires the package to already exist — which `ax` does (the name
-came with prior versions), so this can be set up at any time:
+Once the first OIDC-published release lands cleanly:
 
-1. npmjs.com → the package → **Settings → Trusted Publisher** → GitHub Actions.
-   Set repository `eralabs-ai/ora-cli` and workflow `release.yml`.
-2. In [`.github/workflows/release.yml`](.github/workflows/release.yml), delete
-   the `NODE_AUTH_TOKEN` line from the *Publish to npm* step (and the comment
-   above it). Everything else already works — the job holds `id-token: write`
-   and publishes with `--provenance`.
-3. Verify with a `dry_run`, then cut a real patch release.
-4. Delete the `NPM_TOKEN` secret and revoke the token on npmjs.com.
+1. Delete the `NPM_TOKEN` repo secret and revoke the token on npmjs.com, if
+   either still exists.
+2. On npmjs.com → `ax` → **Settings → Publishing access**, switch to *Require
+   two-factor authentication and disallow bypass 2fa tokens*. Only do this
+   after OIDC is proven — it kills token-based publishing, fallback included.
 
 ## If you protect `main`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,4 @@
-# Releasing `@ora-ai/ax`
+# Releasing `ax`
 
 Releases are manual, deliberate, and run entirely in CI. Nobody publishes from a
 laptop.
@@ -17,7 +17,7 @@ laptop.
    skill invokes (today: `audit` and the flags its playbook shows), bump the
    pinned `CLI_RANGE` in the main repo's
    `src/lib/mcp/skills-content/agent-ready-website.ts` in the same breath and
-   run `npm run skills:gen` there - the skill's `npx @ora-ai/ax@<range>` calls
+   run `npm run skills:gen` there - the skill's `npx ax@<range>` calls
    resolve only the release line the playbook documents, so a range left
    behind quietly routes agents to the API fallback instead of the new CLI.
 
@@ -32,8 +32,9 @@ Rehearse anything uncertain with `dry_run` checked: it does every step including
 
 ### `NPM_TOKEN`
 
-Create a **granular access token** on npmjs.com with read+write on the `@ora-ai`
-scope, then:
+Create a **granular access token** on npmjs.com with read+write on the `ax`
+**package** — `ax` is unscoped, so a token limited to the `@ora-ai` scope does
+*not* cover it; select the package explicitly (or "all packages"). Then:
 
 ```sh
 gh secret set NPM_TOKEN --repo eralabs-ai/ora-cli
@@ -44,15 +45,24 @@ work. Give it an expiry and diarise the rotation.
 
 ### npm org
 
-The `@ora-ai` scope must exist on npmjs.com and the token's account needs publish
-rights on it. The scope is unclaimed as of the first release — claim it before
-someone else does.
+`ax` is unscoped but org-administered: scope and ownership are independent on
+npm. The package's owners are the `ora-ai` org maintainers, and the
+`ora-ai:developers` team holds a read-write grant
+(`npm access grant read-write ora-ai:developers ax`), so org members publish to
+it exactly as they do to `@ora-ai/*` packages. The token's account needs that
+access.
 
-## The first release
+## The rename from `@ora-ai/ax`
 
-`package.json` is at `0.1.0` and nothing is published yet. Any bump would skip
-`0.1.0` and make `0.1.1` your first version. To ship `0.1.0` itself, run the
-workflow with **`version_bump: none`**.
+Versions ≤ `0.5.3` shipped as `@ora-ai/ax`; the plain `ax` name was acquired in
+August 2026 and everything from the first `ax` release onward ships there. Two
+consequences:
+
+- `ax@0.0.1`–`0.2.2` predate us — an unrelated 2011 logging library that came
+  with the name. All are deprecated and must never be reused; every release must
+  version above them (the `0.5.x` line already does).
+- `@ora-ai/ax` stays published but deprecated, its message pointing here. Don't
+  publish to it again.
 
 ## When something goes wrong
 
@@ -86,10 +96,8 @@ pointing at the replacement.
 
 Trusted Publishing removes the long-lived `NPM_TOKEN` entirely: npm verifies the
 workflow's identity through GitHub's OIDC provider instead of a stored
-credential. It requires the package to already exist, which is why the first
-release uses a token.
-
-Once `@ora-ai/ax` is published:
+credential. It requires the package to already exist — which `ax` does (the name
+came with prior versions), so this can be set up at any time:
 
 1. npmjs.com → the package → **Settings → Trusted Publisher** → GitHub Actions.
    Set repository `eralabs-ai/ora-cli` and workflow `release.yml`.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@ora-ai/ax",
+	"name": "ax",
 	"version": "0.5.3",
 	"description": "Score any site's agent readiness and watch real AI agents navigate it — powered by ora",
 	"type": "module",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -4,7 +4,7 @@
 // tsup inlines package.json at build time (src/main.ts imports it), so a build
 // that ran *before* a version bump would publish a binary whose `ax --version`
 // lies. The release workflow bumps then builds; this asserts that ordering held.
-// Also checks the things that break `npx @ora-ai/ax` but never break `pnpm test`:
+// Also checks the things that break `npx ax` but never break `pnpm test`:
 // a missing shebang or a non-executable bin.
 
 import { execFileSync } from "node:child_process";

--- a/src/contract/index.ts
+++ b/src/contract/index.ts
@@ -43,7 +43,7 @@ export function warnOnNewerContract(payloadVersion: string | undefined): void {
 	warned = true;
 	process.stderr.write(
 		`ora reports contract ${payloadVersion}; this CLI was built against ${BUILT_AGAINST}. ` +
-			"Newer fields may be missing from the output - upgrade with: npm i -g @ora-ai/ax@latest\n",
+			"Newer fields may be missing from the output - upgrade with: npm i -g ax@latest\n",
 	);
 }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -26,7 +26,7 @@ export function loadLocalEnv(): boolean {
 		process.loadEnvFile();
 		return true;
 	} catch {
-		// No .env here. The common case: `npx @ora-ai/ax scan` needs no config.
+		// No .env here. The common case: `npx ax audit` needs no config.
 		return false;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-// The library surface of @ora-ai/ax: the same contract-typed client the CLI
-// commands use, importable as `import { audit } from "@ora-ai/ax"`. The bin
+// The library surface of ax: the same contract-typed client the CLI
+// commands use, importable as `import { audit } from "ax"`. The bin
 // stays a separate self-contained bundle - this entry ships unminified with
 // type declarations and has no runtime dependencies.
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig([
 	// The bin: one self-contained CJS executable. citty and picocolors are
-	// bundled in (noExternal), so `npx @ora-ai/ax` has zero install friction.
+	// bundled in (noExternal), so `npx ax` has zero install friction.
 	{
 		entry: { main: "src/main.ts" },
 		format: ["cjs"],
@@ -16,7 +16,7 @@ export default defineConfig([
 			options.minify = true;
 		},
 	},
-	// The library: `import { audit } from "@ora-ai/ax"` - esm + cjs, unminified,
+	// The library: `import { audit } from "ax"` - esm + cjs, unminified,
 	// no shebang. It has no runtime dependencies (picocolors and citty are
 	// CLI-only), so nothing needs bundling here. Declarations come from
 	// `tsc -p tsconfig.lib.json` in the build script: tsup's dts step needs the


### PR DESCRIPTION
## What

Renames the package from `@ora-ai/ax` to plain **`ax`** — `npx ax audit` becomes real — and switches publishing to **tokenless OIDC Trusted Publishing**.

npm-side prep is already done (verified against the registry):
- `ax` transferred to `liady`, gadora + gadshalev added as owners
- legacy `ax@0.0.1–0.2.2` (unrelated 2011 logging library) all deprecated
- `ora-ai:developers` team granted read-write on `ax`
- Trusted publisher configured on npmjs.com: GitHub Actions, `eralabs-ai/ora-cli`, `release.yml`, no environment, `npm publish` allowed

## Changes

- `package.json` name → `ax` (the release workflow reads the name from package.json, so the rename itself needs no CI change)
- README / comments / user-facing upgrade hint (`npm i -g ax@latest`) updated
- `release.yml`: publish step no longer uses `NPM_TOKEN`; new step upgrades npm to 11 — trusted publishing needs npm ≥ 11.5.1 and Node 22 bundles npm 10, which silently skips the OIDC exchange
- RELEASING.md: OIDC steady state documented (incl. the environment-name coupling and the granular-token fallback, noting a `@ora-ai`-scope token does **not** cover unscoped `ax`); new "rename" section records the version-floor constraint (never reuse ≤ 0.2.2) and that `@ora-ai/ax` stays deprecated-but-published
- Drive-by: stale `npx … scan` comment in `src/env.ts` → `audit`

## After merging

1. Dispatch Release with `dry_run` once to rehearse, then with a **minor** bump → `ax@0.6.0` (sits above both legacy `ax@0.2.2` and `@ora-ai/ax@0.5.3`).
2. `npm deprecate @ora-ai/ax "Renamed to ax — run: npx ax"`.
3. Delete/revoke the old `NPM_TOKEN`, and flip npmjs Publishing access to strict 2FA (steps in RELEASING.md).
4. ora-repo follow-up: bump the CLI range in `src/lib/mcp/skills-content/agent-ready-website.ts`, `skills:gen`, plus `nav.ts`, `docs/page.tsx`, `docs/api.md`, `docs/api-consumers.md` — **must wait for step 1**, since `npx ax@0.5` resolves nothing until a modern `ax` version exists.

Gate: lint ✓ typecheck ✓ 95/95 tests ✓ smoke ✓ verify:pack (`ax@0.5.3` tarball) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfEBJbEtwhc4MKrAM3qMh1