### PR TITLE
ci: run checks on main pushes, add aggregate gate, add contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Something in ax is broken
+labels: bug
+---
+
+## What happened
+
+## What you expected
+
+## Reproduction
+
+```sh
+# exact command(s) run
+```
+
+## Environment
+
+- `ax --version`:
+- Node version:
+- OS:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/eralabs-ai/ora-cli/security/advisories/new
+    about: Report security issues privately — never in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an improvement to ax
+labels: enhancement
+---
+
+## Problem
+
+<!-- What can't you do today, or what is awkward? -->
+
+## Proposed solution
+
+## Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+The PR title becomes the squash-merge commit on main, so it must be a
+Conventional Commit: feat: / fix: / chore(scope): / docs: / ci: …
+CI lints it automatically.
+-->
+
+## What
+
+<!-- What does this change do, from a user's point of view? -->
+
+## Why
+
+<!-- Link the issue if one exists. -->
+
+## Checks
+
+- [ ] `pnpm lint && pnpm typecheck && pnpm test` pass locally
+- [ ] Behavior change is covered by a test (or explain why not)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # Push runs keep main's badge honest and catch anything that lands outside
+  # the PR flow (an admin bypass, a release workflow push).
+  push:
+    branches: [main]
   # The contract-drift job below is the alarm for "ora shipped a contract this
   # build was not generated against". Until now it only ran on our own PRs, so
   # nothing woke it when ora released: 1.20.0 shipped and every `ax` run warned
@@ -31,7 +35,7 @@ jobs:
   quality:
     name: Lint & Typecheck
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -57,7 +61,7 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     strategy:
       # One Node version failing shouldn't hide the result on the others.
       fail-fast: false
@@ -84,7 +88,7 @@ jobs:
   build:
     name: Build & Package
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -138,3 +142,22 @@ jobs:
 
       - name: Fail on drift
         run: git diff --exit-code src/contract
+
+  # Aggregate gate: branch protection on `main` requires a single status check
+  # named `ci` instead of chasing per-matrix job names. contract-drift is
+  # deliberately excluded — drift means ora shipped, not that this PR is wrong,
+  # and a required check nobody's PR can fix teaches everyone to bypass gates.
+  ci:
+    runs-on: ubuntu-latest
+    needs: [quality, test, build]
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'push')
+    steps:
+      - name: Verify every required job passed
+        env:
+          RESULTS: quality=${{ needs.quality.result }} test=${{ needs.test.result }} build=${{ needs.build.result }}
+        run: |
+          echo "$RESULTS"
+          if [ "${{ needs.quality.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.build.result }}" != "success" ]; then
+            exit 1
+          fi
+          echo "All required checks passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to ax
+
+Thanks for helping improve `ax`, the Ora CLI.
+
+## Setup
+
+Requires Node >= 20.12 and [pnpm](https://pnpm.io) (version pinned in the
+`packageManager` field of `package.json` — `corepack enable` picks it up).
+
+```sh
+pnpm install
+```
+
+## Working on a change
+
+```sh
+pnpm test          # vitest, watch mode
+pnpm lint          # biome
+pnpm typecheck     # tsc --noEmit
+pnpm build         # bundle to dist/
+pnpm smoke         # run the bundled binary the way a user would
+pnpm verify:pack   # prove the npm tarball would be publishable
+```
+
+CI runs lint, typecheck, tests on Node 20/22/24, build, smoke, and the pack
+check on every PR. All of it must be green before merge.
+
+## Commit messages and PR titles
+
+This repo squash-merges, so **your PR title becomes the commit message on
+`main`** and must follow [Conventional Commits](https://www.conventionalcommits.org/)
+(`feat: …`, `fix: …`, `chore(scope): …`). CI lints the title on every PR;
+individual commit messages on your branch are yours to shape freely.
+
+## Contract types
+
+`src/contract/` is generated from the production Ora OpenAPI spec — never
+edit it by hand. If the scheduled contract-drift job is red, run
+`pnpm contract:gen`, review the diff, and commit the result.
+
+## Releases
+
+Maintainers release via the manual `Release` workflow (see `RELEASING.md`).
+Contributors never need to bump versions or publish.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately via GitHub's
+[private vulnerability reporting](https://github.com/eralabs-ai/ora-cli/security/advisories/new)
+("Report a vulnerability" under the repo's Security tab).
+
+Do **not** open a public issue for a security problem.
+
+We aim to acknowledge reports within a few business days. Please include a
+reproduction and the version of `ax` affected (`ax --version`).
+
+## Supported versions
+
+Only the latest published version on npm receives security fixes.


### PR DESCRIPTION
## What

Adopts the remaining dev-practice gaps identified from the `ora` repo (its PR-title linting already landed here in #26):

- **CI on `push: main`** — every job previously ran only on `pull_request`, so a direct or bypass push to main ran nothing but contract-drift. Quality/test/build now also run on main pushes (release bump commits still skip via `[skip ci]`).
- **Aggregate `ci` gate job** — one stable required-check name for branch protection instead of chasing the three matrix job names. `contract-drift` is deliberately excluded: upstream drift means ora shipped, not that the PR is wrong.
- **CONTRIBUTING.md** — setup, local check commands, and the squash-merge rule (PR title = commit on main, conventionally linted).
- **SECURITY.md** — points at GitHub private vulnerability reporting, no published email.
- **Issue + PR templates** — minimal bug/feature forms; the PR template repeats the title convention where authors will actually see it.

## After merge (repo settings, not doable via PR)

```sh
# Enable private vulnerability reporting
gh api -X PUT repos/eralabs-ai/ora-cli/private-vulnerability-reporting

# Protect main: require PRs + the aggregate 'ci' check + the PR-title check
gh api -X PUT repos/eralabs-ai/ora-cli/branches/main/protection --input - <<'JSON'
{
  "required_status_checks": {"strict": false, "contexts": ["ci", "Conventional commit title"]},
  "enforce_admins": false,
  "required_pull_request_reviews": null,
  "restrictions": null,
  "allow_force_pushes": false,
  "allow_deletions": false
}
JSON
```

(`enforce_admins: false` + no required reviews keeps solo-maintainer merges unblocked while still forcing the PR + green-CI path; the release workflow's push to main is unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)