### PR TITLE
feat(deep-journey): live attribution graph, journey metrics, and a nicer finale

### DIFF
--- a/src/api/deep-journey.test.ts
+++ b/src/api/deep-journey.test.ts
@@ -119,6 +119,37 @@ describe("performDeepJourney", () => {
 		expect(lines.some((line) => line.includes("step 1"))).toBe(true);
 	});
 
+	it("hands each trajectory frame's cumulative steps to onTrajectory", async () => {
+		vi.stubGlobal(
+			"fetch",
+			journeyMock({
+				stream: journeyStream([
+					["run_id", { run_id: RUN_ID }],
+					["trajectory", { steps: [{ id: 0, type: "tool_call", action: "fetch" }] }],
+					[
+						"trajectory",
+						{
+							steps: [
+								{ id: 0, type: "tool_call", action: "fetch" },
+								{ id: 1, type: "tool_call", action: "search" },
+							],
+						},
+					],
+					["result", (realDetail as { result: unknown }).result],
+				]),
+			}),
+		);
+
+		const frames: number[] = [];
+		await performDeepJourney("vercel.com", {
+			...OPTIONS,
+			onTrajectory: (steps) => frames.push(steps.length),
+		});
+
+		// One call per trajectory frame, each carrying the cumulative tree.
+		expect(frames).toEqual([1, 2]);
+	});
+
 	it("treats a capped 200 as a cached outcome, not an error", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/src/api/deep-journey.ts
+++ b/src/api/deep-journey.ts
@@ -77,6 +77,12 @@ export interface DeepJourneyOptions {
 	model: string;
 	/** Receives one-line progress updates while the run streams/polls. */
 	progress?: (line: string) => void;
+	/**
+	 * Receives the cumulative trajectory on every `trajectory` frame - the raw
+	 * material the caller redraws the live attribution graph from. Streaming
+	 * only; polling has no per-step frames to hand back.
+	 */
+	onTrajectory?: (steps: JourneyTrajectoryStep[]) => void;
 	/** Base URL override; otherwise $ORA_API_URL, otherwise https://ora.ai. */
 	baseUrl?: string;
 	/** Abort when the stream is silent for this long (default 120s). */
@@ -308,6 +314,7 @@ async function followJourneyStream(
 					const steps = (payload.steps ?? []) as JourneyTrajectoryStep[];
 					const active = steps.filter((s) => s.type === "tool_call").at(-1);
 					options.progress?.(`step ${steps.length} · ${activityLabel(active ?? steps.at(-1))}`);
+					options.onTrajectory?.(steps);
 				} else if (decoded.event === "processing") {
 					options.progress?.(
 						typeof payload.message === "string" ? payload.message : "generating insights…",

--- a/src/commands/deep-journey.test.ts
+++ b/src/commands/deep-journey.test.ts
@@ -93,4 +93,166 @@ describe("deepJourneyCommand - keyed tier flags", () => {
 		expect(code).toBe(EXIT.OK);
 		expect(performDeepJourney).toHaveBeenCalled();
 	});
+
+	it("draws the attribution graph from the terminal trajectory (non-json)", async () => {
+		const logs: string[] = [];
+		vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+			logs.push(String(line ?? ""));
+		});
+		vi.mocked(performDeepJourney).mockResolvedValueOnce({
+			// biome-ignore lint/suspicious/noExplicitAny: partial record is enough for this render path
+			record: { id: "run_1", status: "succeeded" } as any,
+			cached: false,
+			allowance: {},
+			detail: {
+				id: "run_1",
+				status: "succeeded",
+				domain: "zapier.com",
+				contractVersion: "1.15.0",
+				result: {
+					outcome: "completed",
+					verdict: "satisfied",
+					trajectory: {
+						steps: [
+							{ id: 0, type: "text", text: "Let me start at the homepage." },
+							{
+								id: 1,
+								type: "tool_call",
+								action: "fetch",
+								tool: "WebFetch",
+								url_host: "zapier.com",
+								url_path: "/pricing",
+								status: 200,
+								attribution: { kind: "prior_knowledge" },
+							},
+						],
+					},
+					// biome-ignore lint/suspicious/noExplicitAny: partial detail is enough for this render path
+				} as any,
+				// biome-ignore lint/suspicious/noExplicitAny: partial detail is enough for this render path
+			} as any,
+		});
+
+		const code = await deepJourneyCommand({
+			url: "zapier.com",
+			json: false,
+			noStream: true,
+			intent: "pricing",
+		});
+
+		expect(code).toBe(EXIT.OK);
+		const out = logs.join("\n");
+		// The graph tally, a fetch box for the visited path, and the reasoning note.
+		expect(out).toContain("steps");
+		expect(out).toContain("zapier.com/pricing");
+		expect(out).toContain("Let me start at the homepage");
+	});
+
+	it("surfaces run_signals metrics and token/cost in the finale", async () => {
+		const logs: string[] = [];
+		vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+			logs.push(String(line ?? ""));
+		});
+		vi.mocked(performDeepJourney).mockResolvedValueOnce({
+			// biome-ignore lint/suspicious/noExplicitAny: partial record is enough for this render path
+			record: { id: "run_1", status: "succeeded" } as any,
+			cached: false,
+			allowance: {},
+			detail: {
+				id: "run_1",
+				status: "succeeded",
+				domain: "zapier.com",
+				step_count: 12,
+				verdict: "satisfied",
+				contractVersion: "1.23.0",
+				result: {
+					outcome: "success",
+					verdict: "satisfied",
+					num_turns: 9,
+					duration_ms: 48300,
+					cost_usd: 0.0423,
+					input_tokens: 11840,
+					output_tokens: 2960,
+					run_signals: {
+						version: 3,
+						intent_category: "signup",
+						category_confidence: "high",
+						outcome: "success",
+						reached_anchor: true,
+						steps_count: 12,
+						search_count: 3,
+						link_following_rate: 0.5,
+						prior_knowledge_ratio: 0.3,
+						signals_observed: [],
+						journey_layers: ["discovery", "identity", "access"],
+					},
+					// Four fetches: 3 OK + 1 404 (reliability 75%); origins: 2 followed
+					// links, 1 web search, 1 prior knowledge over 4 → on-site 75%.
+					trajectory: {
+						steps: [
+							{
+								id: 0,
+								type: "tool_call",
+								action: "fetch",
+								status: 200,
+								attribution: { kind: "prior_knowledge" },
+							},
+							{
+								id: 1,
+								type: "tool_call",
+								action: "fetch",
+								status: 200,
+								attribution: { kind: "previous_artifact" },
+							},
+							{ id: 2, type: "tool_call", action: "search", search_query: "q" },
+							{
+								id: 3,
+								type: "tool_call",
+								action: "fetch",
+								status: 404,
+								attribution: { kind: "web_search" },
+							},
+							{
+								id: 4,
+								type: "tool_call",
+								action: "fetch",
+								status: 200,
+								attribution: { kind: "previous_artifact" },
+							},
+						],
+					},
+					insight: { summary: "Reached checkout via the pricing page.", key_observations: [] },
+					// biome-ignore lint/suspicious/noExplicitAny: partial detail is enough for this render path
+				} as any,
+				// biome-ignore lint/suspicious/noExplicitAny: partial detail is enough for this render path
+			} as any,
+		});
+
+		const code = await deepJourneyCommand({
+			url: "zapier.com",
+			json: false,
+			noStream: true,
+			intent: "pricing", // the only intent the module mock's roster offers
+		});
+
+		expect(code).toBe(EXIT.OK);
+		const out = logs.join("\n");
+		// Chip row: token total (input+output) and cost.
+		expect(out).toContain("14.8k tokens");
+		expect(out).toContain("$0.042");
+		expect(out).toContain("3 searches");
+		// The three canonical journey metrics, computed from the trajectory.
+		expect(out).toContain("on-site discovery");
+		expect(out).toContain("reliability");
+		expect(out).toContain("link following");
+		expect(out).toContain("75%"); // on-site (3/4 non-web-search) and reliability (3/4 OK)
+		expect(out).toContain("50%"); // link following = run_signals.link_following_rate
+		// Reach + layers context from run_signals.
+		expect(out).toContain("reached the site");
+		expect(out).toContain("discovery");
+		expect(out).toContain("access");
+		// The intent-category line and the turns chip are intentionally not shown.
+		expect(out).not.toContain("turns");
+		expect(out).not.toContain("intent signup");
+	});
 });

--- a/src/commands/deep-journey.ts
+++ b/src/commands/deep-journey.ts
@@ -8,6 +8,11 @@ import {
 	type JourneyAgentOption,
 	performDeepJourney,
 } from "../api/deep-journey";
+import type { JourneyStep } from "../api/platform";
+import type { JourneyRunResult, JourneyTrajectoryStep } from "../contract";
+import { flow, plain, stdoutWidth } from "../ui/ansi";
+import { buildJourneyTree, drawJourneyTree, journeySummary } from "../ui/graph";
+import { LivePanel } from "../ui/panel";
 import { spinner } from "../ui/spinner";
 
 // `ax deep-journey <url>`: run a real agent at a site through ora's PUBLIC
@@ -59,24 +64,215 @@ function agentLine(agent: JourneyAgentOption): string {
 	return `${agent.label} · ${agent.variant}`;
 }
 
+// The live graph (ui/graph) is written against the platform `JourneyStep`
+// shape; the public journey stream speaks the contract `JourneyTrajectoryStep`.
+// This bridges the two so `deep-journey` draws the very same attribution tree
+// `ax journey` does. Two field-name gaps to close:
+//   · the graph reads `input_display` for the box label — searches carry it in
+//     `search_query`, fetches in `url_host`/`url_path` (which we re-assemble
+//     into a scheme-qualified URL so the graph's splitUrl can parse it).
+//   · the tree edge lives in `attribution.referrer.step_id` for the graph;
+//     the contract also exposes it as the top-level `parent_id`, so fall back.
+function toGraphStep(step: JourneyTrajectoryStep): JourneyStep {
+	const isSearch = step.action === "search";
+	const inputDisplay = isSearch
+		? step.search_query
+		: step.url_host || step.url_path
+			? `https://${step.url_host ?? ""}${step.url_path ?? ""}`
+			: step.url;
+	return {
+		id: step.id,
+		turn: step.turn ?? 0,
+		type: step.type,
+		// Contract text steps are the agent's narrative reasoning between actions;
+		// tag them so the graph attaches them as (…) notes above the next box.
+		kind: step.type === "text" ? "reasoning" : undefined,
+		text: step.text,
+		thinking: step.text,
+		tool: step.tool,
+		action: step.action,
+		input_display: inputDisplay,
+		status: step.status,
+		duration_ms: step.duration_ms,
+		attribution: step.attribution
+			? {
+					kind: step.attribution.kind,
+					referrer: { step_id: step.attribution.referrer?.step_id ?? step.parent_id },
+				}
+			: undefined,
+	};
+}
+
+// The attribution tree plus its one-line tally, indented to match the report.
+// `settled` false paints the newest box as the live/active node.
+function graphLines(steps: JourneyStep[], intent: string, settled: boolean): string[] {
+	return [
+		`  ${journeySummary(steps)}`,
+		"",
+		...drawJourneyTree(buildJourneyTree(steps, intent, settled)).map((row) => `  ${row}`),
+	];
+}
+
+// --- Finale ---
+
+const chipTokens = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n));
+
+function chipCost(usd: number): string {
+	if (usd < 0.01) return `$${usd.toFixed(4)}`;
+	if (usd < 1) return `$${usd.toFixed(3)}`;
+	return `$${usd.toFixed(2)}`;
+}
+
+/** input + output; the meaningful "how big was this run" figure (cache is separate). */
+function totalTokens(result: JourneyRunResult | undefined): number | undefined {
+	if (!result) return undefined;
+	const { input_tokens: i, output_tokens: o } = result;
+	if (i == null && o == null) return undefined;
+	return (i ?? 0) + (o ?? 0);
+}
+
+function countSearches(result: JourneyRunResult | undefined): number {
+	return (result?.trajectory?.steps ?? []).filter((s) => s.action === "search").length;
+}
+
+// The three canonical journey metrics ora's product shows, computed here from
+// the trajectory exactly as the engine does (run-recap.tsx score helpers):
+//   · on-site discovery = 1 − web-search share of fetches   (green ≥70, amber ≥40)
+//   · reliability       = HTTP-2xx share of non-search fetches (100 green, ≥85 green, ≥60 amber)
+//   · link following    = previous-artifact share of fetches (≡ run_signals.link_following_rate)
+// Each renders only when it has steps to score, so a search-only run omits them
+// rather than printing a fake 0.
+interface JourneyMetric {
+	label: string;
+	pct: number;
+	paint: (s: string) => string;
+}
+
+function tierColor(pct: number, good: number, warn: number): (s: string) => string {
+	return pct >= good ? pc.green : pct >= warn ? pc.yellow : pc.red;
+}
+
+function journeyMetrics(result: JourneyRunResult): JourneyMetric[] {
+	const steps = result.trajectory?.steps ?? [];
+	// Path-origin denominator: fetch / api_call steps (searches excluded).
+	const paths = steps.filter(
+		(s) => s.type === "tool_call" && (s.action === "fetch" || s.action === "api_call"),
+	);
+	// Reliability denominator: any non-search tool call that observed a status.
+	const fetches = steps.filter((s) => s.type === "tool_call" && s.action && s.action !== "search");
+
+	const metrics: JourneyMetric[] = [];
+
+	if (paths.length) {
+		const webSearch =
+			paths.filter((s) => s.attribution?.kind === "web_search").length / paths.length;
+		const pct = Math.round((1 - webSearch) * 100);
+		metrics.push({ label: "on-site discovery", pct, paint: tierColor(pct, 70, 40) });
+	}
+
+	if (fetches.length) {
+		const ok = fetches.filter((s) => s.status != null && s.status >= 200 && s.status < 300).length;
+		const pct = Math.round((ok / fetches.length) * 100);
+		metrics.push({
+			label: "reliability",
+			pct,
+			paint: pct === 100 ? pc.green : tierColor(pct, 85, 60),
+		});
+	}
+
+	if (paths.length) {
+		// Prefer the engine's own rate; it is previous_artifact / fetches by definition.
+		const rate =
+			result.run_signals?.link_following_rate ??
+			paths.filter((s) => s.attribution?.kind === "previous_artifact").length / paths.length;
+		const pct = Math.round(rate * 100);
+		metrics.push({ label: "link following", pct, paint: tierColor(pct, 70, 35) });
+	}
+
+	return metrics;
+}
+
+// A labelled 0–100% bar, tinted by the metric's own score tier (the same
+// green/amber/red coding the product's cards use).
+function metricLine(metric: JourneyMetric, cells = 20): string {
+	const lit = Math.max(0, Math.min(cells, Math.round((metric.pct / 100) * cells)));
+	const bar = `${metric.paint("▰".repeat(lit))}${pc.dim("▱".repeat(cells - lit))}`;
+	const pct = `${metric.pct}%`.padStart(4);
+	return `  ${pc.dim(metric.label.padEnd(17))}  ${bar}  ${metric.paint(pc.bold(pct))}`;
+}
+
+function rule(wide: number): string {
+	return pc.dim(`  ${"─".repeat(Math.min(wide - 4, 52))}`);
+}
+
+// The behavioral read of the run: the three canonical journey metrics (derived
+// from the trajectory, so they show on every completed run) plus the reach /
+// intent / layers context from run_signals (experimental, often absent on the
+// keyless tier — each renders only when the server sent it).
+function signalLines(result: JourneyRunResult): string[] {
+	const sig = result.run_signals;
+	const rows: string[] = [];
+
+	// Reach context (run_signals only).
+	if (sig?.reached_anchor != null) {
+		const reach = sig.reached_anchor
+			? pc.green("✓ reached the site")
+			: pc.red("✗ never reached the site");
+		rows.push("", `  ${reach}`);
+	}
+
+	// The three canonical journey metrics, tinted by score tier.
+	const metrics = journeyMetrics(result);
+	if (metrics.length) {
+		rows.push("");
+		for (const metric of metrics) rows.push(metricLine(metric));
+	}
+
+	const layers = sig?.journey_layers ?? result.insight?.journey_layers;
+	if (layers?.length) {
+		rows.push("", `  ${pc.dim("layers")}  ${layers.map((l) => pc.bold(l)).join(pc.dim(" › "))}`);
+	}
+	return rows;
+}
+
 function renderOutcome(outcome: DeepJourneyOutcome, url: string): string[] {
+	const wide = stdoutWidth(60, 120);
 	const { detail } = outcome;
-	const lines: string[] = [""];
+	const result = detail.result;
+	const lines: string[] = ["", rule(wide), ""];
 
-	lines.push(`${verdictLine(detail.verdict, detail.status)}  ${pc.dim(detail.domain ?? url)}`);
+	// Verdict headline.
+	lines.push(
+		`  ${verdictLine(detail.verdict, detail.status)}  ${pc.dim("·")}  ${pc.dim(detail.domain ?? url)}`,
+	);
 
+	// One chip row: size and cost of the run at a glance.
 	const chips: string[] = [];
 	if (detail.step_count != null) chips.push(`${detail.step_count} steps`);
-	const result = detail.result;
-	if (result?.num_turns != null) chips.push(`${result.num_turns} turns`);
+	const searches = result?.run_signals?.search_count ?? countSearches(result);
+	if (searches) chips.push(`${searches} search${searches === 1 ? "" : "es"}`);
 	if (result?.duration_ms != null) chips.push(`${(result.duration_ms / 1000).toFixed(1)}s`);
-	if (chips.length) lines.push(pc.dim(chips.join(" · ")));
+	const tokens = totalTokens(result);
+	if (tokens != null) chips.push(`${chipTokens(tokens)} tokens`);
+	if (result?.cost_usd != null) chips.push(chipCost(result.cost_usd));
+	if (chips.length) lines.push(`  ${pc.dim(chips.join("  ·  "))}`);
 
+	// Behavioral signals (reach, intent, link-following, layers) when present.
+	if (result) lines.push(...signalLines(result));
+
+	// The generated read, wrapped to width; observations as bullets beneath it.
 	if (result?.insight?.summary) {
-		lines.push("", result.insight.summary);
+		lines.push("");
+		for (const row of flow(plain(result.insight.summary), wide - 4)) lines.push(`  ${row}`);
 	}
-	for (const observation of result?.insight?.key_observations ?? []) {
-		lines.push(pc.dim(`  - ${observation}`));
+	const observations = result?.insight?.key_observations ?? [];
+	if (observations.length) {
+		lines.push("", `  ${pc.bold("Observations")}`);
+		for (const observation of observations) {
+			const [first, ...rest] = flow(plain(observation), wide - 6);
+			lines.push(`    ${pc.cyan("·")} ${first}`);
+			for (const row of rest) lines.push(`      ${row}`);
+		}
 	}
 
 	if (detail.status === "failed") {
@@ -84,13 +280,13 @@ function renderOutcome(outcome: DeepJourneyOutcome, url: string): string[] {
 			"",
 			pc.dim(
 				outcome.engineError
-					? `Engine error: ${outcome.engineError} — re-running is free to try.`
-					: "The run ended in an engine error; re-running is free to try.",
+					? `  Engine error: ${outcome.engineError} — re-running is free to try.`
+					: "  The run ended in an engine error; re-running is free to try.",
 			),
 		);
 	}
 
-	lines.push("", pc.dim(`For the 4-layer readiness audit, run: ax audit ${url}`));
+	lines.push("", pc.dim(`  For the 4-layer readiness audit, run: ax audit ${url}`));
 	return lines;
 }
 
@@ -128,6 +324,9 @@ export async function deepJourneyCommand(input: DeepJourneyCommandInput): Promis
 	// text as-is (anchored to the target) instead of a template id.
 	let intentId = input.intent;
 	let agent: JourneyAgentOption;
+	// The goal drawn at the graph's root: the free-text task verbatim, or the
+	// curated intent's own phrasing (template › hint › label), never a bare id.
+	let intentText = task ?? "journey";
 	try {
 		const [intents, agents] = await Promise.all([
 			task ? undefined : fetchJourneyIntents(),
@@ -144,6 +343,8 @@ export async function deepJourneyCommand(input: DeepJourneyCommandInput): Promis
 				);
 				return EXIT.USAGE;
 			}
+			const chosen = intents.intents.find((option) => option.id === intentId);
+			intentText = chosen?.template || chosen?.hint || chosen?.label || intentId || "journey";
 		}
 		const wantedAgent = input.agent ?? agents.defaultId;
 		const found = agents.agents.find((option) => option.id === wantedAgent);
@@ -163,9 +364,37 @@ export async function deepJourneyCommand(input: DeepJourneyCommandInput): Promis
 	if (!input.json) {
 		console.error(pc.dim(apiKey ? KEYED_CAPS_LINE : CAPS_LINE));
 	}
-	if (interactive) {
+
+	// The live attribution graph draws itself from the streamed trajectory, so
+	// it only lights up when we're both on a TTY and actually streaming. With
+	// --no-stream (no per-step frames) or a bare pipe, we fall back to the
+	// one-line spinner and let the terminal graph print once at the end.
+	const live = interactive && !input.noStream;
+	const panel = new LivePanel();
+	let steps: JourneyStep[] = [];
+	let headline = `waking ${agent.label}`;
+	const repaint = () => panel.draw(graphLines(steps, intentText, false), headline);
+
+	if (live) {
+		console.log();
+		console.log(
+			`  ${pc.cyan("▶")} ${pc.bold(target)}  ${pc.dim("·")}  ${pc.dim(agentLine(agent))}  ${pc.dim("·")}  ${pc.dim(task ? "custom task" : (intentId ?? "default"))}`,
+		);
+		console.log();
+		panel.open();
+		repaint();
+	} else if (interactive) {
 		spinner.start(`Sending ${agentLine(agent)} to ${target} (${task ? `"${task}"` : intentId})`);
 	}
+
+	const progress = (line: string) => {
+		if (live) {
+			headline = line;
+			repaint();
+		} else if (interactive) {
+			spinner.update(line);
+		}
+	};
 
 	let outcome: DeepJourneyOutcome;
 	try {
@@ -176,14 +405,22 @@ export async function deepJourneyCommand(input: DeepJourneyCommandInput): Promis
 			harness: agent.harness,
 			model: agent.model,
 			noStream: input.noStream,
-			progress: interactive ? (line) => spinner.update(line) : undefined,
+			progress: interactive ? progress : undefined,
+			onTrajectory: live
+				? (raw) => {
+						steps = raw.map(toGraphStep);
+						repaint();
+					}
+				: undefined,
 		});
 	} catch (error) {
-		if (interactive) spinner.stop();
+		if (live) panel.close();
+		else if (interactive) spinner.stop();
 		if (error instanceof DeepJourneyApiError) return fail(error.message);
 		return fail(error instanceof Error ? error.message : String(error));
 	}
-	if (interactive) spinner.stop();
+	if (live) panel.close();
+	else if (interactive) spinner.stop();
 
 	if (input.json) {
 		console.log(JSON.stringify(outcome.detail, null, 2));
@@ -204,6 +441,16 @@ export async function deepJourneyCommand(input: DeepJourneyCommandInput): Promis
 				`allowance: ${outcome.allowance.remaining} of ${outcome.allowance.limit} target runs left in the 24h window`,
 			),
 		);
+	}
+
+	// The permanent copy: redraw the graph from the terminal detail's trajectory
+	// (the authoritative, complete tree - which can carry more steps than the
+	// last stream frame did) so the attribution picture survives past the live
+	// region and also shows up on a bare pipe or under --no-stream.
+	const finalSteps = (outcome.detail.result?.trajectory?.steps ?? []).map(toGraphStep);
+	if (finalSteps.length) {
+		console.log();
+		for (const line of graphLines(finalSteps, intentText, true)) console.log(line);
 	}
 
 	for (const line of renderOutcome(outcome, target)) console.log(line);

--- a/src/ui/panel.test.ts
+++ b/src/ui/panel.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LivePanel } from "./panel";
+
+// The live region redraws in place with an absolute cursor-up, which can only
+// reach the top of the viewport. A frame taller than the terminal would scroll
+// and the repaint would stack ghost copies (the deep-journey duplication bug).
+// These lock in that every painted frame fits the viewport.
+
+describe("LivePanel viewport clamp", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	function paintAndCapture(rows: number, content: string[]): string {
+		const priorTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		const priorRows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "rows", { value: rows, configurable: true });
+		let written = "";
+		vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+			written += String(chunk);
+			return true;
+		});
+		try {
+			const panel = new LivePanel();
+			panel.draw(content, "working");
+			return written;
+		} finally {
+			if (priorTTY) Object.defineProperty(process.stdout, "isTTY", priorTTY);
+			if (priorRows) Object.defineProperty(process.stdout, "rows", priorRows);
+		}
+	}
+
+	it("never paints more lines than the viewport holds", () => {
+		const content = Array.from({ length: 200 }, (_, i) => `  box ${i}`);
+		const written = paintAndCapture(24, content);
+		// Count the content rows actually emitted (each frame line is "\x1b[2K…\n").
+		const painted = written.split("\n").length - 1;
+		expect(painted).toBeLessThanOrEqual(24);
+	});
+
+	it("keeps the newest lines and marks how many were hidden", () => {
+		const content = Array.from({ length: 200 }, (_, i) => `  box ${i}`);
+		const written = paintAndCapture(24, content);
+		expect(written).toContain("box 199"); // the tail (newest) survives
+		expect(written).toContain("earlier lines"); // the hidden-count marker
+		expect(written).not.toContain("box 0"); // the head is dropped, not stacked
+	});
+
+	it("leaves short content untouched", () => {
+		const written = paintAndCapture(40, ["  only", "  three", "  lines"]);
+		expect(written).toContain("only");
+		expect(written).toContain("lines");
+		expect(written).not.toContain("earlier line");
+	});
+
+	it("keeps the in-place cursor-up within the viewport as the region grows", () => {
+		const priorTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		const priorRows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		const VIEWPORT = 20;
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		Object.defineProperty(process.stdout, "rows", { value: VIEWPORT, configurable: true });
+		let written = "";
+		vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+			written += String(chunk);
+			return true;
+		});
+		try {
+			const panel = new LivePanel();
+			// Redraw a region that keeps growing well past the viewport height.
+			for (let n = 1; n <= 100; n++) {
+				panel.draw(
+					Array.from({ length: n }, (_, i) => `  box ${i}`),
+					"working",
+				);
+			}
+			// Every in-place jump-up (ESC[NA) must stay within the viewport; a value
+			// larger than the screen is exactly what scrolled and stacked ghosts.
+			// (Swap the ESC byte for a literal so the matcher carries no control char.)
+			const jumps = [...written.replaceAll("\x1b", "ESC").matchAll(/ESC\[(\d+)A/g)].map((m) =>
+				Number(m[1]),
+			);
+			expect(jumps.length).toBeGreaterThan(0);
+			expect(Math.max(...jumps)).toBeLessThanOrEqual(VIEWPORT);
+		} finally {
+			if (priorTTY) Object.defineProperty(process.stdout, "isTTY", priorTTY);
+			if (priorRows) Object.defineProperty(process.stdout, "rows", priorRows);
+		}
+	});
+});

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -48,9 +48,28 @@ export class LivePanel {
 		return `  ${glyph} ${pc.bold(text)}`;
 	}
 
+	// The live region repaints itself in place with an absolute cursor-up
+	// (\x1b[NA), which can only reach the top of the *viewport* — never into
+	// scrollback. So a frame taller than the terminal would scroll, the cursor
+	// math would under-shoot, and every repaint would stack a fresh ghost copy
+	// below the last (and close() could no longer erase them). We bound the
+	// frame to the viewport: banner + a blank + as much content as fits, kept
+	// from the TAIL (the newest, most interesting nodes) with a marker for the
+	// rest. The caller prints the full, untruncated view once at the end.
+	private clamp(content: string[]): string[] {
+		const budget = Math.max(2, (process.stdout.rows ?? 24) - 3); // banner + blank + slack
+		if (content.length <= budget) return content;
+		const shown = budget - 1; // ≥ 1: one line reserved for the "earlier lines" marker
+		const hidden = content.length - shown;
+		return [
+			pc.dim(`  ⋯ ${hidden} earlier line${hidden === 1 ? "" : "s"}`),
+			...content.slice(-shown),
+		];
+	}
+
 	private repaint(): void {
 		if (!this.live) return;
-		const frame = [this.banner(), "", ...this.content];
+		const frame = [this.banner(), "", ...this.clamp(this.content)];
 		let out = this.rows > 0 ? `\x1b[${this.rows}A` : "";
 		for (const row of frame) out += `\x1b[2K${row}\n`;
 		if (frame.length < this.rows) out += "\x1b[0J"; // wipe leftovers of a taller frame


### PR DESCRIPTION
## What & why

`ax deep-journey` only showed a one-line spinner while a run streamed, even though the public journey stream carries the full per-step **attribution** data — the same material `ax journey` renders as a live tree. This wires that visualization into `deep-journey`, fixes a panel ghosting bug it surfaced, and surfaces run metrics the API already returns.

## Changes

- **Live attribution graph.** Stream the trajectory into the same `LivePanel` + attribution tree `ax journey` draws, via a small adapter from the contract's `JourneyTrajectoryStep` to the graph's step shape. Falls back to the spinner under `--no-stream`/non-TTY; the full tree always prints once at the end (so it shows on a bare pipe too).
- **Panel ghosting fix.** The live region repaints with an absolute cursor-up (`ESC[NA`), which can only reach the top of the viewport. A tree taller than the terminal scrolled, the cursor under-shot, and each repaint stacked a duplicate frame (and `close()` couldn't erase them). `LivePanel` now clamps the live frame to the viewport — showing the newest tail while live — so it never scrolls. Also hardens `ax journey`, which shares the panel.
- **More metrics from the API.** Token count, `cost_usd`, search count, reach, and journey layers — previously discarded — now render in the finale (defensively; each only when present).
- **The three canonical journey metrics** — **on-site discovery**, **reliability**, **link following** — computed from the trajectory with the same formulas and green/amber/red tiers as ora's product cards (`run-recap.tsx` score helpers).
- **Nicer finale.** Rule divider, width-wrapped summary (run through `plain()` to strip control chars, since insight text can echo fetched page content), and bulleted observations.

## Testing

- New `src/ui/panel.test.ts` — asserts the live frame never exceeds the viewport, including a growth simulation where the cursor-up jumps stay bounded (the exact invariant the ghosting bug violated).
- New command/API tests for `onTrajectory` delivery, graph render from the terminal trajectory, and the metrics/token/cost finale.
- Full suite: **158 passing / 2 skipped**; typecheck and lint clean (only a pre-existing `env.test` warning).

## Notes

- The three metrics are the **legacy** trio from the product. The orank redesign proposal suggests dropping "on-site discovery" (a superset of link following) — happy to follow that framing if preferred.
- Newer v4 answer-grounding signals (`answer_basis.site_share`, `answer_efficiency`, cited-source tiers) are richer but need a public-contract bump before the CLI can read them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)