### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ax",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "Score any site's agent readiness and watch real AI agents navigate it — powered by ora",
 	"type": "module",
 	"packageManager": "pnpm@10.34.5",
@@ -16,7 +16,10 @@
 	},
 	"main": "./dist/index.cjs",
 	"types": "./dist/index.d.ts",
-	"files": ["dist", ".env.example"],
+	"files": [
+		"dist",
+		".env.example"
+	],
 	"engines": {
 		"node": ">=22.4.0"
 	},
@@ -51,7 +54,10 @@
 		"access": "public"
 	},
 	"pnpm": {
-		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild"]
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"esbuild"
+		]
 	},
 	"license": "MIT",
 	"homepage": "https://ora.ai",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
 	},
 	"main": "./dist/index.cjs",
 	"types": "./dist/index.d.ts",
-	"files": [
-		"dist",
-		".env.example"
-	],
+	"files": ["dist", ".env.example"],
 	"engines": {
 		"node": ">=22.4.0"
 	},
@@ -54,10 +51,7 @@
 		"access": "public"
 	},
 	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@biomejs/biome",
-			"esbuild"
-		]
+		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild"]
 	},
 	"license": "MIT",
 	"homepage": "https://ora.ai",


### PR DESCRIPTION
Records the `0.7.0` release that is already live on npm.

## Why this is needed

`0.7.0` published successfully on 2026-08-31 at 19:09:56Z and is the current `latest` on npm. The release workflow then failed at its next step — pushing the version bump to `main` — because branch protection rejected it:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 2 of 2 required status checks are expected.
```

So npm has the release and git does not. That ordering is deliberate (the workflow publishes first because npm versions are immutable and a git commit is cheap to redo), and `RELEASING.md` documents this exact recovery. This PR is the first of its three steps.

**Re-running the Release workflow cannot fix it** — it would try to publish `0.7.0` a second time and get `403 You cannot publish over the previously published versions`.

## What happens after this merges

```sh
git checkout main && git pull
git tag -a v0.7.0 -m "Release v0.7.0"
git push origin v0.7.0
gh release create v0.7.0 --title v0.7.0 --generate-notes --verify-tag
```

Tagging the bump commit keeps this consistent with previous releases — `v0.6.0` points at its own `chore(release): v0.6.0` commit.

## Note on the second commit

`npm version` rewrites `package.json` with its own formatter, expanding the short arrays biome keeps inline, which fails the Lint check. The release workflow has a "Normalise formatting after bump" step for exactly that; running the bump by hand skips it. The net diff against `main` is one line.

## This will recur

The underlying cause is unfixed: the release job pushes a `[skip ci]` commit to a protected `main` that requires two status checks, and `[skip ci]` means those checks never run — so the push can never be allowed. The next release fails the same way.

Two ways out: give the release workflow a bypass on the branch rule, or change it to open a PR for the bump rather than pushing to `main`. Worth doing before the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)