### PR TITLE
fix(webmcp): give the live-Chrome setup hook a real timeout

### DIFF
--- a/src/webmcp/capture.live.test.ts
+++ b/src/webmcp/capture.live.test.ts
@@ -61,6 +61,11 @@ describe.skipIf(!LIVE)("captureLocally against a real Chrome", () => {
 	let endpoint: BrowserEndpoint;
 	let stopChrome: () => Promise<void> = async () => {};
 
+	// Launching a real Chrome is the slow part of setup: a cold CI runner routinely
+	// takes longer than vitest's 10s default hook timeout, which fired mid-launch
+	// and left `server` unassigned (so afterAll then threw on `server.close`). Give
+	// the hook the same 90s budget the tests get, and guard teardown against a
+	// setup that bailed before it built either resource.
 	beforeAll(async () => {
 		if (ENDPOINT) {
 			endpoint = await discoverEndpoint(ENDPOINT);
@@ -75,12 +80,12 @@ describe.skipIf(!LIVE)("captureLocally against a real Chrome", () => {
 		});
 		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
 		url = `http://127.0.0.1:${(server.address() as { port: number }).port}/`;
-	});
+	}, 90_000);
 
 	afterAll(async () => {
-		await new Promise((resolve) => server.close(resolve));
+		if (server) await new Promise((resolve) => server.close(resolve));
 		await stopChrome();
-	});
+	}, 90_000);
 
 	it("finds the tool the page registers, and reports the browser honestly", async () => {
 		const capture = await captureLocally({ url, endpoint });


### PR DESCRIPTION
## What

The `Capture (real browser)` CI job intermittently fails during setup, not in a test:

```
FAIL  src/webmcp/capture.live.test.ts > captureLocally against a real Chrome
Error: Hook timed out in 10000ms.
 ❯ src/webmcp/capture.live.test.ts:64:2   (beforeAll)

FAIL  src/webmcp/capture.live.test.ts > captureLocally against a real Chrome
TypeError: Cannot read properties of undefined (reading 'close')
 ❯ src/webmcp/capture.live.test.ts:81:41  (afterAll)
```

## Root cause

`beforeAll` launches a **real Chrome** (`launchChrome()`), but ran under vitest's **10 s default hook timeout** — while the two tests themselves are given 90 s. A cold GitHub-hosted runner routinely takes longer than 10 s to cold-start Chrome (with `--no-sandbox`), so the hook times out **mid-launch**. Because it bailed before assigning `server`, the `afterAll` then threw `Cannot read properties of undefined (reading 'close')`, which masked the real cause.

It's a flake, not a regression: the same job passed on the immediately preceding and following runs, and `feat/webmcp-audit` showed the same failure-then-pass pattern.

## Fix

- Give `beforeAll` (and `afterAll`) the same **90 s** budget the tests already use, so Chrome launch has room.
- Guard teardown (`if (server) …`) so a setup that bailed early tears down cleanly instead of throwing a misleading secondary error.

No production code changes; the suite still skips cleanly without `AX_WEBMCP_LIVE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)