### PR TITLE
chore(release): v0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ax",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"description": "Score any site's agent readiness and watch real AI agents navigate it — powered by ora",
 	"type": "module",
 	"packageManager": "pnpm@10.34.5",


### PR DESCRIPTION
Records the `0.7.1` release that is already live on npm. One-line diff.

## Why this is needed

`0.7.1` published successfully at 2026-09-02 17:08:33Z and is the current `latest` on npm. The release workflow then failed at its next step, pushing the version bump to `main`:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 2 of 2 required status checks are expected.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

Same failure as `v0.7.0` ([#30](https://github.com/eralabs-ai/ora-cli/pull/30)), for the same reason. npm has the release and git does not.

**Do not re-run the Release workflow to fix this** — it would try to publish `0.7.1` a second time and get `403 You cannot publish over the previously published versions`.

## After this merges

```sh
git checkout main && git pull
git tag -a v0.7.1 -m "Release v0.7.1"
git push origin v0.7.1
gh release create v0.7.1 --title v0.7.1 --generate-notes --verify-tag
```

Tags carry no protection rule, so those go through.

## This will keep happening

`main` requires two status checks: `ci` and `Conventional commit title`. The second runs on `pull_request` only, so a direct push can never produce it — and required checks block a push whose commit has no passing checks, which a freshly created release commit never can. Direct pushes to `main` are impossible by construction, so the release workflow deadlocks every time.

Fixing it means either giving the release job a bypass on the branch rule, or changing it to open a PR for the bump instead of pushing to `main`. Tracked separately from this reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)