### PR TITLE
fix(webmcp-audit): give the live capture hooks their own timeout

### DIFF
--- a/src/webmcp/capture.live.test.ts
+++ b/src/webmcp/capture.live.test.ts
@@ -55,8 +55,18 @@ const PAGE = `<!doctype html>
   }
 </script></body></html>`;
 
+/**
+ * Ceiling for the setup hook. Vitest's default is 10s, which is fine for the
+ * page server and NOT for launching Chrome on a cold CI runner - measured at
+ * over 10s there, while a warm local machine does it in about two. The `it`
+ * timeouts below do not cover a hook, so this has to be its own.
+ */
+const HOOK_TIMEOUT_MS = 90_000;
+
 describe.skipIf(!LIVE)("captureLocally against a real Chrome", () => {
-	let server: Server;
+	// Both undefined until `beforeAll` finishes. A hook that times out still runs
+	// `afterAll`, so teardown must not assume either exists.
+	let server: Server | undefined;
 	let url: string;
 	let endpoint: BrowserEndpoint;
 	let stopChrome: () => Promise<void> = async () => {};
@@ -69,18 +79,24 @@ describe.skipIf(!LIVE)("captureLocally against a real Chrome", () => {
 			endpoint = chrome.endpoint;
 			stopChrome = chrome.close;
 		}
-		server = createServer((_req, res) => {
+		// Assigned to a local first, so the rest of the hook is not narrowing the
+		// possibly-undefined field it has to leave behind for teardown.
+		const listener = createServer((_req, res) => {
 			res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
 			res.end(PAGE);
 		});
-		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-		url = `http://127.0.0.1:${(server.address() as { port: number }).port}/`;
-	});
+		server = listener;
+		await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+		url = `http://127.0.0.1:${(listener.address() as { port: number }).port}/`;
+	}, HOOK_TIMEOUT_MS);
 
 	afterAll(async () => {
-		await new Promise((resolve) => server.close(resolve));
+		// Guarded, and the browser is stopped even if the server never started:
+		// throwing here would replace the real failure with a teardown error and
+		// leak a Chrome. `stopChrome` is a no-op until the launch succeeded.
+		if (server) await new Promise((resolve) => server?.close(resolve));
 		await stopChrome();
-	});
+	}, HOOK_TIMEOUT_MS);
 
 	it("finds the tool the page registers, and reports the browser honestly", async () => {
 		const capture = await captureLocally({ url, endpoint });


### PR DESCRIPTION
The `Capture (real browser)` job failed on [#32](https://github.com/eralabs-ai/ora-cli/pull/32) — a one-line version bump, so nothing in that diff caused it.

```
Error: Hook timed out in 10000ms.
 ❯ src/webmcp/capture.live.test.ts:64:2

TypeError: Cannot read properties of undefined (reading 'close')
 ❯ src/webmcp/capture.live.test.ts:81:41
```

## Cause

`beforeAll` launches Chrome. Vitest's default **hook** timeout is 10s, and the `90_000` timeouts in this file are on the `it`s — they do not cover a hook. Launching a browser on a cold runner takes longer than 10s; a warm laptop does it in about two, which is why this passed twice before failing.

The timeout then cascaded into a misleading second error: `afterAll` still runs after a hook times out, and it called `server.close()` on a server `beforeAll` had not reached yet. The real failure was buried under a `TypeError`.

## Fix

- An explicit `HOOK_TIMEOUT_MS` on both hooks.
- Teardown guarded, and it stops the browser even when the page server never started — otherwise a timed-out setup leaks a Chrome on the runner.

## Verified

Both paths locally: the happy one (2 passed), and a deliberately unreachable `AX_WEBMCP_CHROME=127.0.0.1:1`, which now skips cleanly with no teardown `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)