### PR TITLE
fix(release): land the version bump via PR instead of pushing to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write # push the bump commit + tag, create the GitHub Release
+      contents: write # push the tag, create the GitHub Release
       id-token: write # OIDC token for npm provenance attestation
+      pull-requests: write # open the version-bump PR (main is protected — no direct push)
     env:
       # setup-node writes an .npmrc referencing ${NODE_AUTH_TOKEN}, so every npm and
       # pnpm call warns until something defines it. Publishing itself is tokenless
@@ -163,34 +164,57 @@ jobs:
             npm publish --access public --provenance
           fi
 
-      # Push only after npm accepted the publish. npm versions are immutable and
-      # effectively unrecoverable; a local commit and tag cost nothing to discard.
-      # If this step fails, npm has the release and git does not — see RELEASING.md.
-      - name: Commit, tag and push
+      # Tag and land the bump only after npm accepted the publish. npm versions
+      # are immutable and effectively unrecoverable; a tag and a branch cost
+      # nothing to discard if anything here fails.
+      #
+      # This never pushes to main. main is protected: a fresh commit pushed
+      # straight to it arrives with no passing status checks, and one required
+      # check ("Conventional commit title") only ever runs on pull_request — so a
+      # direct push is rejected by construction and the release deadlocks. Instead
+      # we tag the built commit (tags carry no protection rule) and land the
+      # package.json bump the same way every other change lands: a branch + PR.
+      - name: Tag the release and open the version-bump PR
         if: ${{ !inputs.dry_run }}
         env:
           TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Stage everything tracked that changed — the bump plus any formatting the
-          # normalise step applied — so the commit can never be a partial snapshot
-          # of what was just published. .gitignore keeps dist/ and coverage/ out.
-          # `none` leaves the tree untouched, so there is nothing to commit.
+          # main's HEAD, unmodified: the exact commit the published artifact was
+          # built from. The bump lives only in the working tree here (npm version
+          # ran --no-git-tag-version and nothing has committed it yet), so HEAD is
+          # still main. Tag THIS, not the bump commit — the repo squash-merges, so
+          # a bump-commit SHA is rewritten on merge and its tag would be orphaned.
+          MAIN_SHA=$(git rev-parse HEAD)
+          git tag -a "$TAG" -m "Release $TAG" "$MAIN_SHA"
+          git push origin "$TAG"
+
+          # `none` leaves the tree untouched — the published version already lives
+          # in package.json on main, so there is nothing to land.
           if git diff --quiet HEAD; then
-            echo "No changes to commit; tagging current HEAD"
-          else
-            git add -A
-            git commit -m "chore(release): $TAG [skip ci]"
-            echo "Committed:"
-            git show --stat --oneline HEAD | tail -n +2
+            echo "No tree changes (bump=none); tag pushed, nothing to land on main."
+            exit 0
           fi
 
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin HEAD:main
-          git push origin "$TAG"
+          # The bump plus any formatting the normalise step applied, on a branch a
+          # human merges. Staging everything tracked keeps the commit from ever
+          # being a partial snapshot of what was just published (dist/ and
+          # coverage/ stay out via .gitignore).
+          BRANCH="chore/release-$TAG"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore(release): $TAG"
+          echo "Committed:"
+          git show --stat --oneline HEAD | tail -n +2
+          git push origin "$BRANCH"
+
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore(release): $TAG" \
+            --body "Records the \`$TAG\` release already published to npm and tagged at \`$MAIN_SHA\`. Merging updates \`package.json\` on main — bump only, safe to squash-merge."
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,9 +212,21 @@ jobs:
           git show --stat --oneline HEAD | tail -n +2
           git push origin "$BRANCH"
 
+          # Opening a PR with the built-in token needs the repo setting "Allow
+          # GitHub Actions to create and approve pull requests" (Settings →
+          # Actions → General); without it this call is refused outright. And a
+          # PR opened by that token never fires pull_request events, so the
+          # required checks (ci, Conventional commit title) will not run on it
+          # until a human closes and reopens it — the reopen fires them as that
+          # human. The body tells the merger exactly that.
           gh pr create --base main --head "$BRANCH" \
             --title "chore(release): $TAG" \
-            --body "Records the \`$TAG\` release already published to npm and tagged at \`$MAIN_SHA\`. Merging updates \`package.json\` on main — bump only, safe to squash-merge."
+            --body "$(cat <<EOF
+          Records the \`$TAG\` release already published to npm and tagged at \`$MAIN_SHA\`. Merging updates \`package.json\` on main — bump only, safe to squash-merge.
+
+          **Checks will not start on their own.** This PR was opened by the release workflow with the built-in Actions token, and PRs opened that way never trigger \`pull_request\` workflows. **Close and reopen this PR** to run the required checks, then merge.
+          EOF
+          )"
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,8 +22,20 @@ laptop.
    behind quietly routes agents to the API fallback instead of the new CLI.
 
 The workflow lints, typechecks, tests, bumps, builds, smoke-tests the bundled
-binary, publishes to npm with provenance, then commits `chore(release): vX.Y.Z`,
-tags it, and opens a GitHub Release with generated notes.
+binary, publishes to npm with provenance, tags the built commit, opens a GitHub
+Release with generated notes, and opens a `chore(release): vX.Y.Z` PR that lands
+the `package.json` bump on `main`.
+
+**Every release leaves one PR to merge.** The workflow deliberately never pushes
+to `main` — see [Why the bump comes as a PR](#why-the-bump-comes-as-a-pr). npm,
+the tag, and the GitHub Release all land automatically in the run; only the
+one-line `package.json` bump waits on that PR. Merge it (squash) to finish the
+release. The version on npm is live regardless of when the PR merges.
+
+Note the tag points at the commit the artifact was **built from** (main's HEAD at
+dispatch), not at the bump commit — so `vX.Y.Z` and its `package.json` bump are
+one commit apart. This is intentional: the repo squash-merges, which rewrites the
+bump commit's SHA, so tagging it would orphan the tag.
 
 Rehearse anything uncertain with `dry_run` checked: it does every step including
 `npm publish --dry-run`, but publishes nothing, commits nothing, pushes nothing.
@@ -73,27 +85,42 @@ consequences:
 
 ## When something goes wrong
 
-The workflow publishes to npm **before** it pushes to git, on purpose: npm
-versions are immutable and effectively permanent, while a local commit and tag
-cost nothing to throw away. That shapes recovery:
+The workflow publishes to npm **before** it tags or opens the bump PR, on
+purpose: npm versions are immutable and effectively permanent, while a tag and a
+branch cost nothing to throw away. That shapes recovery:
 
-**Failed before or during publish** — nothing was pushed and nothing reached npm.
+**Failed before or during publish** — nothing reached npm and nothing was tagged.
 Fix the cause and re-run. The bump lived only in the runner's working copy.
 
-**Published, but the push failed** — npm has the release and git does not. This
-usually means `main` moved between checkout and push. Reconcile by hand:
+**Published, but tagging or the PR step failed** — npm has the release; the tag,
+the GitHub Release, or the bump PR is missing. Nothing here is destructive to
+redo, and none of it touches `main` directly. Finish by hand — do only the parts
+that are actually missing (check `git ls-remote --tags origin`, `gh release
+list`, and `gh pr list`):
 
 ```sh
-git checkout main && git pull
-npm version <the-published-version> --no-git-tag-version
-git commit -am "chore(release): v<the-published-version>"
-git tag -a "v<the-published-version>" -m "Release v<the-published-version>"
-git push origin main --follow-tags
-gh release create "v<the-published-version>" --generate-notes --verify-tag
+V=<the-published-version>   # e.g. 0.7.2
+
+# 1. Tag the commit the artifact was built from (main's HEAD at release time —
+#    usually current main if it hasn't moved) and the GitHub Release.
+git fetch origin
+git tag -a "v$V" -m "Release v$V" origin/main   # pick the real build SHA if main moved
+git push origin "v$V"
+gh release create "v$V" --title "v$V" --generate-notes --verify-tag
+
+# 2. Land the package.json bump via a PR — a direct push to protected main is
+#    rejected by construction (that is the deadlock this flow exists to avoid).
+git checkout -b "chore/release-v$V" origin/main
+npm version "$V" --no-git-tag-version
+npx biome check --write package.json   # npm version reformats it; Lint fails otherwise
+git commit -am "chore(release): v$V"
+git push -u origin "chore/release-v$V"
+gh pr create --title "chore(release): v$V" --body "Records the v$V release already live on npm."
 ```
 
-Do **not** re-run the Release workflow to fix this — the preflight check will
-correctly refuse, because that version is already on npm.
+Do **not** re-run the Release workflow to fix a stuck release — the preflight
+check will correctly refuse, because that version is already on npm (`403 You
+cannot publish over the previously published versions`).
 
 **Wrong version published** — you cannot reuse or overwrite a version. Publish
 the fix forward under a new version. `npm deprecate` the bad one with a message
@@ -109,13 +136,26 @@ Once the first OIDC-published release lands cleanly:
    two-factor authentication and disallow bypass 2fa tokens*. Only do this
    after OIDC is proven — it kills token-based publishing, fallback included.
 
-## If you protect `main`
+## Why the bump comes as a PR
 
-The release job pushes its bump commit and tag directly to `main` using the
-built-in `GITHUB_TOKEN`. `main` is currently unprotected, so this works as-is.
-If you add branch protection, that push starts failing — grant the exception via
-a bypass allowance for GitHub Actions in the ruleset, or swap the checkout token
-for a PAT that can bypass it.
+`main` is protected: two status checks are required (`ci` and `Conventional
+commit title`), and one of them — `Conventional commit title` — only ever runs on
+`pull_request`. A commit pushed straight to `main` therefore can **never** satisfy
+the ruleset: the required checks run only after the ref updates, which the
+protection won't allow until they pass. So a direct push from the release job is
+rejected by construction and the release deadlocks after the (immutable) npm
+publish. This bit `v0.7.0`, `v0.7.1`, and `v0.7.2`, each reconciled by hand.
+
+The workflow sidesteps it entirely: **tags** carry no protection rule, so the tag
+and GitHub Release push straight through; the `package.json` bump lands through a
+normal PR that runs the required checks and a human merges. Nothing is ever pushed
+to `main` directly.
+
+If you would rather keep everything atomic in one run (tag semantics unchanged,
+no leftover PR), the alternative is to give the release job a **bypass** on the
+branch rule — add a bypass actor for GitHub Actions in the ruleset, or push with a
+GitHub App / PAT that can bypass required checks. That costs a permanent hole in
+the branch protection plus a secret to manage; the PR flow above needs neither.
 
 ## Optional hardening
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,8 +29,12 @@ the `package.json` bump on `main`.
 **Every release leaves one PR to merge.** The workflow deliberately never pushes
 to `main` — see [Why the bump comes as a PR](#why-the-bump-comes-as-a-pr). npm,
 the tag, and the GitHub Release all land automatically in the run; only the
-one-line `package.json` bump waits on that PR. Merge it (squash) to finish the
-release. The version on npm is live regardless of when the PR merges.
+one-line `package.json` bump waits on that PR. **Close and reopen the PR, then
+merge it (squash)** to finish the release. The close/reopen is not optional: the
+PR is opened with the built-in Actions token, and PRs opened that way never
+trigger `pull_request` workflows, so the required checks stay "expected" until a
+human reopens it — the reopen fires them as that human. The version on npm is
+live regardless of when the PR merges.
 
 Note the tag points at the commit the artifact was **built from** (main's HEAD at
 dispatch), not at the bump commit — so `vX.Y.Z` and its `package.json` bump are
@@ -41,6 +45,31 @@ Rehearse anything uncertain with `dry_run` checked: it does every step including
 `npm publish --dry-run`, but publishes nothing, commits nothing, pushes nothing.
 
 ## One-time setup
+
+### Let the workflow open the bump PR
+
+The release job opens the `chore(release)` PR with the built-in `GITHUB_TOKEN`.
+GitHub refuses that by default ("GitHub Actions is not permitted to create or
+approve pull requests") — the `pull-requests: write` grant in the workflow is
+not enough on its own. Enable it once, repo-wide:
+
+**Settings → Actions → General → Workflow permissions → Allow GitHub Actions to
+create and approve pull requests**. The org-level setting gates the repo one
+(the repo call returns `409 The organization does not allow GitHub Actions to
+create or approve pull requests` until it is on), so enable both, org first:
+
+```sh
+gh api -X PUT orgs/eralabs-ai/actions/permissions/workflow \
+  -F default_workflow_permissions=read -F can_approve_pull_request_reviews=true
+gh api -X PUT repos/eralabs-ai/ora-cli/actions/permissions/workflow \
+  -F default_workflow_permissions=read -F can_approve_pull_request_reviews=true
+```
+
+Turning it on at the org only makes it available to repos; it does not switch
+it on for any of them, which is why the second call is still needed.
+
+Without this, every release fails at the PR step after the tag is already
+pushed, and the GitHub Release never gets created.
 
 ### OIDC Trusted Publishing
 
@@ -150,6 +179,11 @@ The workflow sidesteps it entirely: **tags** carry no protection rule, so the ta
 and GitHub Release push straight through; the `package.json` bump lands through a
 normal PR that runs the required checks and a human merges. Nothing is ever pushed
 to `main` directly.
+
+One wrinkle: PRs opened with the built-in Actions token do not trigger
+`pull_request` workflows (GitHub's guard against recursive runs), so the bump PR
+arrives with its required checks stuck at "expected". Closing and reopening it as
+a human fires the checks under that human's identity. The PR body says so.
 
 If you would rather keep everything atomic in one run (tag semantics unchanged,
 no leftover PR), the alternative is to give the release job a **bypass** on the


### PR DESCRIPTION
## The bug

The Release workflow **deadlocks on every run**. It publishes to npm successfully, then fails on the next step trying to push the bump commit to `main`:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 2 of 2 required status checks are expected.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

Result: npm has the release, git doesn't — no bump on `main`, no tag, no GitHub Release. `v0.7.0`, `v0.7.1`, and `v0.7.2` all had to be reconciled by hand.

## Why (structural, not tuning)

`main` requires two checks: `ci` and `Conventional commit title`. The latter only runs on `pull_request`, so a commit pushed **directly** to `main` can never produce it — and required checks only run after the ref updates, which the ruleset won't allow until they pass. A direct push from the release job is rejected by construction. Removing `[skip ci]` doesn't help; the `pull_request`-only check stands regardless.

## The fix

Never push to `main`. **Tags carry no protection rule**, so:

1. Record `main`'s HEAD **before** the bump is committed — the commit the published artifact was built from.
2. Tag that SHA and push the tag.
3. Create the GitHub Release from the tag (unchanged).
4. Land the `package.json` bump on a `chore/release-vX.Y.Z` branch via `gh pr create` — a human merges it.

Adds `pull-requests: write` to the job.

## Trade-offs (stated, not hidden)

- **Tags now point at the built commit**, not the `chore(release)` bump commit like `v0.6.0`/`v0.7.0` did. This is deliberate: the repo squash-merges, which rewrites a branch bump commit's SHA on merge and would orphan a tag placed on it.
- **Every release leaves one PR to merge.** npm + tag + GitHub Release still land automatically in the run; only the one-line `package.json` bump waits on that PR — which is exactly the manual reconciliation being done today, now automated.

`RELEASING.md` is updated to match: the new flow, a rewritten recovery section, and a "Why the bump comes as a PR" section (replacing "If you protect main", which described the now-removed direct push). The admin-bypass alternative is documented there too.

> Note: this does not reconcile `v0.7.2`, which is already published to npm but missing from git — that's handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)