### PR TITLE
chore(release): v0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ax",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"description": "Score any site's agent readiness and watch real AI agents navigate it — powered by ora",
 	"type": "module",
 	"packageManager": "pnpm@10.34.5",


### PR DESCRIPTION
Records the **`v0.7.2` release already published to npm** (`npm view ax version` → `0.7.2`) but missing from git — the Release run published successfully, then died on the push to protected `main` (the deadlock fixed in #35).

This is the one-line `package.json` bump the release needs. Bump only — safe to squash-merge.

## After this merges

The tag and GitHub Release for `v0.7.2` are also still missing and should be created once this lands:

```sh
git fetch origin
git tag -a v0.7.2 -m "Release v0.7.2" origin/main
git push origin v0.7.2
gh release create v0.7.2 --title v0.7.2 --generate-notes --verify-tag
```

Do **not** re-run the Release workflow — `0.7.2` is immutable on npm and the preflight will (correctly) refuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)