### PR TITLE
chore: point repository references at eralabs-ai/ax

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/eralabs-ai/ora-cli/security/advisories/new
+    url: https://github.com/eralabs-ai/ax/security/advisories/new
     about: Report security issues privately — never in a public issue.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,7 +61,7 @@ create or approve pull requests` until it is on), so enable both, org first:
 ```sh
 gh api -X PUT orgs/eralabs-ai/actions/permissions/workflow \
   -F default_workflow_permissions=read -F can_approve_pull_request_reviews=true
-gh api -X PUT repos/eralabs-ai/ora-cli/actions/permissions/workflow \
+gh api -X PUT repos/eralabs-ai/ax/actions/permissions/workflow \
   -F default_workflow_permissions=read -F can_approve_pull_request_reviews=true
 ```
 
@@ -76,7 +76,7 @@ pushed, and the GitHub Release never gets created.
 Publishing is tokenless: npm verifies the workflow's identity through GitHub's
 OIDC provider. The trusted publisher is configured on npmjs.com → `ax` →
 **Settings → Trusted Publisher**: GitHub Actions, org `eralabs-ai`, repository
-`ora-cli`, workflow `release.yml`, no environment, `npm publish` allowed. The
+`ax`, workflow `release.yml`, no environment, `npm publish` allowed. The
 workflow's `id-token: write` permission plus npm ≥ 11.5.1 (the job upgrades
 npm explicitly — Node 22 bundles npm 10, which silently skips the OIDC
 exchange) are the only other requirements.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a vulnerability
 
 Please report vulnerabilities privately via GitHub's
-[private vulnerability reporting](https://github.com/eralabs-ai/ora-cli/security/advisories/new)
+[private vulnerability reporting](https://github.com/eralabs-ai/ax/security/advisories/new)
 ("Report a vulnerability" under the repo's Security tab).
 
 Do **not** open a public issue for a security problem.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 	"homepage": "https://ora.ai",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/eralabs-ai/ora-cli.git"
+		"url": "git+https://github.com/eralabs-ai/ax.git"
 	},
 	"keywords": [
 		"ai",


### PR DESCRIPTION
Repo renamed from `ora-cli` to `ax` on GitHub; npm trusted publisher already updated to match. This updates every in-repo reference: `package.json` repository.url, `SECURITY.md`, the issue template contact link, and the trusted-publisher instructions in `RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)