### PR TITLE
chore: update repository URLs after org transfer to ora

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/eralabs-ai/ax/security/advisories/new
+    url: https://github.com/ora/ax/security/advisories/new
     about: Report security issues privately — never in a public issue.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,9 +59,9 @@ create and approve pull requests**. The org-level setting gates the repo one
 create or approve pull requests` until it is on), so enable both, org first:
 
 ```sh
-gh api -X PUT orgs/eralabs-ai/actions/permissions/workflow \
+gh api -X PUT orgs/ora/actions/permissions/workflow \
   -F default_workflow_permissions=read -F can_approve_pull_request_reviews=true
-gh api -X PUT repos/eralabs-ai/ax/actions/permissions/workflow \
+gh api -X PUT repos/ora/ax/actions/permissions/workflow \
   -F default_workflow_permissions=read -F can_approve_pull_request_reviews=true
 ```
 
@@ -75,7 +75,7 @@ pushed, and the GitHub Release never gets created.
 
 Publishing is tokenless: npm verifies the workflow's identity through GitHub's
 OIDC provider. The trusted publisher is configured on npmjs.com → `ax` →
-**Settings → Trusted Publisher**: GitHub Actions, org `eralabs-ai`, repository
+**Settings → Trusted Publisher**: GitHub Actions, org `ora`, repository
 `ax`, workflow `release.yml`, no environment, `npm publish` allowed. The
 workflow's `id-token: write` permission plus npm ≥ 11.5.1 (the job upgrades
 npm explicitly — Node 22 bundles npm 10, which silently skips the OIDC

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a vulnerability
 
 Please report vulnerabilities privately via GitHub's
-[private vulnerability reporting](https://github.com/eralabs-ai/ax/security/advisories/new)
+[private vulnerability reporting](https://github.com/ora/ax/security/advisories/new)
 ("Report a vulnerability" under the repo's Security tab).
 
 Do **not** open a public issue for a security problem.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 	"homepage": "https://ora.ai",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/eralabs-ai/ax.git"
+		"url": "git+https://github.com/ora/ax.git"
 	},
 	"keywords": [
 		"ai",


### PR DESCRIPTION
## Summary
The repo was transferred from `eralabs-ai` to `ora`. GitHub redirects the old paths, but package metadata, plugin manifests, docs, and issue templates should point at the canonical location.

- Replaces every `eralabs-ai` reference with `ora`
- No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)