### PR TITLE
chore(deps): override transitive undici to 6.28 for the Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
 		"access": "public"
 	},
 	"pnpm": {
-		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild"]
+		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild"],
+		"overrides": {
+			"undici@<6.28.0": "^6.28.0"
+		}
 	},
 	"license": "MIT",
 	"author": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici@<6.28.0: ^6.28.0
+
 importers:
 
   .:
@@ -526,10 +529,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1562,9 +1561,9 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici@6.28.1:
+    resolution: {integrity: sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==}
+    engines: {node: '>=18.17'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -2014,8 +2013,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.2':
     optional: true
-
-  '@fastify/busboy@2.1.1': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2691,7 +2688,7 @@ snapshots:
       fast-glob: 3.3.3
       js-yaml: 4.3.1
       supports-color: 9.4.0
-      undici: 5.29.0
+      undici: 6.28.1
       yargs-parser: 21.1.1
 
   package-json-from-dist@1.0.1: {}
@@ -2958,9 +2955,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@6.28.1: {}
 
   vite-node@3.2.4(@types/node@26.2.0)(jiti@2.6.1):
     dependencies:


### PR DESCRIPTION
## What

Closes the 8 open Dependabot alerts on `undici@5.29.0` (dev-only, reached only via `openapi-typescript@6.7.6`) with a pnpm override to `^6.28.0`. Dependabot's security job failed because it cannot update a transitive dependency in a pnpm lockfile.

`openapi-typescript` stays on v6 on purpose (v7 needs the TS compiler API that TypeScript 7 does not expose, see the comment in `scripts/contract-gen.mjs`). The generator only receives an already-fetched spec object, so its undici code path is not exercised; `pnpm contract:gen` output is byte-identical.

The remaining low-severity esbuild alert (dev-server file read, `esbuild@0.27.7` via tsup) is not fixable without leaving tsup's `^0.27` range; tsup never starts the dev server, so it is dismissed as not used.

## Checks

- `pnpm lint`, `pnpm typecheck`, `pnpm build`: clean
- `pnpm vitest run`: 158 passed, 2 skipped
- `pnpm contract:gen`: no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBcNk3LwzgSkJrbs8As61D
