### PR TITLE
ci: format JSON the way release-please writes it

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,17 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
-	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {
@@ -15,7 +25,7 @@
 	},
 	"json": {
 		"formatter": {
-			"expand": "auto"
+			"expand": "always"
 		}
 	},
 	"files": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
 	},
 	"main": "./dist/index.cjs",
 	"types": "./dist/index.d.ts",
-	"files": ["dist", ".env.example"],
+	"files": [
+		"dist",
+		".env.example"
+	],
 	"engines": {
 		"node": ">=22.4.0"
 	},
@@ -51,7 +54,10 @@
 		"access": "public"
 	},
 	"pnpm": {
-		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild"],
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"esbuild"
+		],
 		"overrides": {
 			"undici@<6.28.0": "^6.28.0"
 		}

--- a/src/api/__fixtures__/deep-journey-detail.json
+++ b/src/api/__fixtures__/deep-journey-detail.json
@@ -423,7 +423,9 @@
 				}
 			],
 			"action_sequence": "fetch,fetch+fetch,fetch,fetch,search+fetch,fetch+fetch,fetch+search,fetch+fetch,search+fetch,fetch+search,fetch+fetch",
-			"signals_observed": ["developer-portal"],
+			"signals_observed": [
+				"developer-portal"
+			],
 			"friction_outcome": "timeout",
 			"status_profile": {
 				"count_2xx": 10,

--- a/src/webmcp/__fixtures__/ora-ai-audit.json
+++ b/src/webmcp/__fixtures__/ora-ai-audit.json
@@ -212,7 +212,9 @@
 										"description": "Domain or URL to scan, e.g. stripe.com"
 									}
 								},
-								"required": ["url"],
+								"required": [
+									"url"
+								],
 								"additionalProperties": false
 							},
 							"annotations": {},
@@ -233,7 +235,9 @@
 										"description": "Apex domain, e.g. stripe.com"
 									}
 								},
-								"required": ["domain"],
+								"required": [
+									"domain"
+								],
 								"additionalProperties": false
 							},
 							"annotations": {
@@ -281,7 +285,9 @@
 							"marker": "document.modelContext",
 							"deprecatedAliasOnly": false
 						},
-						"polyfillPackages": ["usewebmcp"],
+						"polyfillPackages": [
+							"usewebmcp"
+						],
 						"keywordMention": true
 					},
 					"apiSurface": {

--- a/src/webmcp/__fixtures__/ora-ai-capture.json
+++ b/src/webmcp/__fixtures__/ora-ai-capture.json
@@ -21,7 +21,9 @@
 								"description": "Domain or URL to scan, e.g. stripe.com"
 							}
 						},
-						"required": ["url"],
+						"required": [
+							"url"
+						],
 						"additionalProperties": false
 					},
 					"annotations": {},
@@ -42,7 +44,9 @@
 								"description": "Apex domain, e.g. stripe.com"
 							}
 						},
-						"required": ["domain"],
+						"required": [
+							"domain"
+						],
 						"additionalProperties": false
 					},
 					"annotations": {
@@ -90,7 +94,9 @@
 					"marker": "document.modelContext",
 					"deprecatedAliasOnly": false
 				},
-				"polyfillPackages": ["usewebmcp"],
+				"polyfillPackages": [
+					"usewebmcp"
+				],
 				"keywordMention": true
 			},
 			"apiSurface": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
 	"compilerOptions": {
 		"target": "ES2022",
-		"lib": ["ES2022"],
+		"lib": [
+			"ES2022"
+		],
 		"module": "ESNext",
 		"moduleResolution": "bundler",
 		"strict": true,
@@ -11,8 +13,15 @@
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"noEmit": true,
-		"types": ["node"]
+		"types": [
+			"node"
+		]
 	},
-	"include": ["src"],
-	"exclude": ["node_modules", "dist"]
+	"include": [
+		"src"
+	],
+	"exclude": [
+		"node_modules",
+		"dist"
+	]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -7,5 +7,7 @@
 		"outDir": "dist",
 		"rootDir": "src"
 	},
-	"include": ["src/index.ts"]
+	"include": [
+		"src/index.ts"
+	]
 }


### PR DESCRIPTION
Release PR #46 failed `Lint & Typecheck`: release-please rewrites `package.json` with every array/object expanded, and biome's `expand: auto` wants short ones inline. Switching to `expand: always` makes biome's output byte-identical to release-please's (verified against #46's package.json). Everything else is a whitespace-only reformat of the repo's JSON files; typecheck and 158 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBcNk3LwzgSkJrbs8As61D